### PR TITLE
fix: allow decimals in qty and persist state when routing to add trade from blotter view

### DIFF
--- a/web/ui/src/components/Blotter/BlotterForm.tsx
+++ b/web/ui/src/components/Blotter/BlotterForm.tsx
@@ -213,7 +213,7 @@ export default function BlotterForm() {
             label="Quantity"
             placeholder="Quantity"
             thousandSeparator=","
-            allowDecimal={false}
+            allowDecimal={true}
             key={form.key("qty")}
             {...form.getInputProps("qty")}
           />

--- a/web/ui/src/components/Blotter/BlotterTable.tsx
+++ b/web/ui/src/components/Blotter/BlotterTable.tsx
@@ -173,12 +173,18 @@ const BlotterTable: React.FC = () => {
   const handleAddTrade = (table: MRT_TableInstance<Trade>): (() => void) => {
     return () => {
       // first check if there is any selections
-      const selection = table
-        .getSelectedRowModel()
-        .rows.map((trade) => trade.original.Ticker);
+      const selection = table.getSelectedRowModel().rows;
       if (selection.length > 0) {
         const ticker = selection[0];
-        navigate("/blotter/add_trade", { state: { ticker } });
+        console.log(ticker);
+        navigate("/blotter/add_trade", {
+          state: {
+            ticker: ticker.original.Ticker,
+            broker: ticker.original.Broker,
+            account: ticker.original.Account,
+            trader: ticker.original.Trader,
+          },
+        });
       } else {
         navigate("/blotter/add_trade");
       }


### PR DESCRIPTION
Resolves: 
- https://github.com/rodionlim/portfolio-manager-go/issues/9
- https://github.com/rodionlim/portfolio-manager-go/issues/10