### PR TITLE
fix(backup): redirect should route to localhost:8888

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,9 +172,11 @@ If you are using a personal Google account, use OAuth2 Desktop credentials inste
 4. Ensure your **OAuth Client ID** in Google Console allows `http://localhost:8888` as a redirect URI (though for Desktop App types, localhost is usually allowed by default).
 5. On first run, follow the link in your terminal. After authorization, you will be redirected to the URI specified in your `credentials.json` (e.g., `http://localhost:8888` or your Tailscale domain) and the application will capture the code automatically.
 6. A `token.json` will be saved locally for future automatic backups.
-7. **Remote Servers (Proxmox/LXC)**: If you are running the app on a remote server, you have two options:
-   - **Option A (Custom Domain)**: Use a reachable domain in your `redirect_uris` (like a Tailscale `.ts.net` address). Ensure port **8888** (or the port in your URI) is open in your server firewall.
-   - **Option B (SSH Tunnel)**: Use `localhost:8888` in your credentials and use SSH port forwarding (`ssh -L 8888:localhost:8888 your-server`) on your local machine during the one-time authentication step.
+7. **Remote Servers (Proxmox/LXC)**: If you are running the app on a remote server, you have two options for the one-time authentication step:
+   - **Option A (Custom Domain)**: Use a reachable domain in your `redirect_uris` (like a Tailscale `.ts.net` address). Ensure port **8888** (or the port in your URI) is open in your server firewall. (*Note: Only works for "Web Application" client types, not "Desktop App"*).
+   - **Option B (Port Forwarding)**: Keep `localhost:8888` in your credentials and "beam" the traffic from your local laptop to the server using one of these commands on your **local machine**:
+     - **SSH Tunnel**: `ssh -L 8888:localhost:8888 your-server`
+     - **Socat**: `socat TCP4-LISTEN:8888,fork TCP4:your-server:8888`
 
 # Nextcloud backup (not yet implemented)
 ./portfolio-manager backup --source nextcloud --uri https://your-nextcloud.com --user username --password password

--- a/internal/backup/gdrive.go
+++ b/internal/backup/gdrive.go
@@ -246,7 +246,7 @@ func (g *GDriveBackupSource) getTokenFromWeb(ctx context.Context, config *oauth2
 	})
 
 	server := &http.Server{
-		Addr:    fmt.Sprintf(":%d", port),
+		Addr:    fmt.Sprintf("0.0.0.0:%d", port),
 		Handler: mux,
 	}
 
@@ -256,17 +256,19 @@ func (g *GDriveBackupSource) getTokenFromWeb(ctx context.Context, config *oauth2
 		}
 	}()
 
-	authURL := config.AuthCodeURL("state-token", oauth2.AccessTypeOffline)
 	fmt.Printf("\nGDrive: Google has blocked the out-of-band (OOB) flow for desktop apps.\n")
 	fmt.Printf("Please follow these steps to authenticate:\n\n")
 
 	fmt.Printf("1. Ensure the redirect URL is reachable: %s\n", config.RedirectURL)
 	if strings.Contains(config.RedirectURL, "localhost") {
-		fmt.Println("   Note: Since this is 'localhost', if you are on a remote server, you may need SSH port forwarding.")
+		fmt.Println("   Note: If you are on a REMOTE server, you must tunnel traffic from your local machine:")
+		fmt.Printf("   A) Using SSH:   ssh -L %d:localhost:%d [user]@[remote-host]\n", port, port)
+		fmt.Printf("   B) Using socat: socat TCP4-LISTEN:%d,fork TCP4:[remote-host]:%d\n", port, port)
 	} else {
 		fmt.Println("   Note: You are using a custom redirect domain. Ensure your firewall allows incoming traffic on the specified port.")
 	}
 
+	authURL := config.AuthCodeURL("state-token", oauth2.AccessTypeOffline)
 	fmt.Println("\n2. Open the following link in your browser:")
 	fmt.Printf("%v\n\n", authURL)
 


### PR DESCRIPTION
Previously, we used redirect url in credentials.json as the redirect url, but that has many complications including requiring client id to be specific, and also https to be used.

Instead, users are recommended to either port-forward via ssh or socat to a remote server if necessary.