### PR TITLE
feat(mdata): add market rotation screener strategy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,7 @@
+# Agent Guidance
+
+## Conditional context
+
+- For work involving TradingView sector ETFs, ETF fund flows, market rotation, USA industry-to-sector mapping, daily stock candidates, or the OpenClaw market brief, read [docs/market-rotation-strategy.md](docs/market-rotation-strategy.md) before acting.
+- For unrelated work, do not load the market-rotation strategy into context.
+

--- a/README.md
+++ b/README.md
@@ -490,6 +490,15 @@ Fetch the Overview, Performance, and Fund Flows tabs for the top 100 global sect
 - `fetch_sector_etf_performance`
 - `fetch_sector_etf_fund_flows`
 
+#### 18. Screen Daily Market Rotation (`screen_daily_market_rotation`)
+
+Build a deterministic US market-rotation payload from the TradingView Sector ETFs Overview, Performance, and Fund Flows tabs plus USA stock-industry and stock-performance data. The tool computes sector-level 1M flows, acceleration, breadth, broad/subsector divergence, industry mappings, setup classifications, and zero to five stock candidates before returning data to the LLM.
+
+- **persist_history**: persist the session for transition detection; defaults to `true`. Use `false` for dry runs.
+- **max_stock_candidates**: maximum candidates from 1 to 5; defaults to 5.
+
+The LLM should narrate the returned ranking without recalculating it and must describe flows as ETF product flows, not direct stock-level institutional flows. See [the OpenClaw prompt and schedule](docs/openclaw-market-rotation.md).
+
 #### Stock Industries vs. Sector ETFs
 
 The MCP server treats these as distinct datasets:

--- a/docs/market-rotation-strategy.md
+++ b/docs/market-rotation-strategy.md
@@ -1,0 +1,128 @@
+# Daily Market-Rotation Strategy
+
+This is the canonical, lazily loaded design and memory document for the TradingView-to-OpenClaw market brief. Keep `AGENTS.md` and memory entries as short pointers to this file rather than copying the strategy into always-on context.
+
+Tracking: [GitHub issue #183](https://github.com/rodionlim/portfolio-manager-go/issues/183), following the raw TradingView integration in [issue #181](https://github.com/rodionlim/portfolio-manager-go/issues/181).
+
+## Objective
+
+Produce a daily, post-US-close brief that explains one-month sector ETF product flows, identifies broad and subsector rotations, drills into matching USA stock industries, and returns zero to five liquid stock candidates. Deterministic Go code owns data joins, calculations, exclusions, classifications, rankings, and history comparisons. The LLM owns concise interpretation only.
+
+The strategy targets weeks-to-months holding periods and prefers confirmed turns over anticipatory entries. It must never fill a candidate quota when no setup qualifies.
+
+## Data and universe
+
+The source is TradingView's [Sector ETFs page](https://www.tradingview.com/markets/etfs/funds-sector-etfs/) via table ID `etfs_funds.sector_etfs`, using its Overview, Performance, and Fund Flows tabs. The raw MCP tools retain the top-100 global screen. The rotation scorer restricts aggregates to US-listed, USD-denominated equity ETFs.
+
+Exclude foreign listings, non-USD funds, non-equity funds, thematic funds, leveraged/inverse products, and single-stock ETFs from sector aggregates. Return exclusion counts by reason.
+
+Classify remaining ETFs as:
+
+- Broad sector: the explicit pairs XLC/VOX, XLY/VCR, XLP/VDC, XLE/VDE, XLF/VFH, XLV/VHT, XLI/VIS, XLB/VAW, XLRE/VNQ, XLK/VGT, and XLU/VPU.
+- Subsector: other eligible, unleveraged sector or industry ETFs.
+
+Subsector ETFs can create an independent secondary signal without claiming that the entire broad sector is confirmed.
+
+## One-month sector flow analysis
+
+For each sector, precompute:
+
+- Combined AUM and 1M/3M ETF product flows.
+- 1M flow as a percentage of combined AUM.
+- Prior two-month average monthly flow: `(Flow3M - Flow1M) / 2`.
+- Flow acceleration: current 1M normalized flow minus the prior two-month normalized monthly pace.
+- Breadth: positive-flow ETF count and percentage.
+- Broad and subsector flow totals and acceleration separately.
+- Broad-versus-subsector agreement or divergence.
+- Up to three genuine positive contributors and three genuine negative detractors.
+- Flow state: accelerating inflow, decelerating inflow, improving outflow, or worsening outflow.
+- History state: baseline, new, newly accelerating, strengthening, weakening, or unchanged.
+
+These are ETF product flows, not direct stock-level institutional flows.
+
+## Performance shape and signal lanes
+
+Convert percentage fields to decimals for compounding calculations, then report percent units. Derive the embedded prior two-month return pace as:
+
+`((1 + R3M) / (1 + R1M))^(1/2) - 1`
+
+Return acceleration is current 1M return minus that prior monthly pace.
+
+Classify setups as:
+
+- Recovery: 6M or 1Y performance is non-positive, followed by positive 1W/1M performance and positive acceleration.
+- Ignition: longer-term performance is below the 60th percentile while recent acceleration is in the top quartile.
+- Continuation: 3M and 6M performance are in the top quartile with positive supporting flow.
+- Unconfirmed: insufficient multi-period confirmation.
+
+Reject actionable setups driven primarily by one top-decile trading day. Maintain three lanes:
+
+1. Broad-sector flow and performance confirmed: highest confidence.
+2. Independent subsector rotation: medium-high confidence and explicitly labeled.
+3. Performance-led industry without flow confirmation: eligible but lower confidence.
+
+Flow disagreement reduces confidence; it does not automatically eliminate strong industry performance.
+
+## Industry mapping
+
+Map at the TradingView industry level rather than treating its 20 stock sectors as equivalent to the 11 ETF sectors. Important splits include:
+
+- Finance → Financials, except REITs and real-estate development → Real Estate.
+- Electronic Technology → Information Technology, except Aerospace & Defense → Industrials.
+- Technology Services → Information Technology, except Internet Software/Services → Communication Services.
+- Consumer Services → Consumer Discretionary, with media, broadcasting, publishing, and cable → Communication Services.
+- Industrial Services → Industrials, with pipelines, drilling, and oilfield services → Energy.
+- Process Industries → Materials, with agricultural commodities → Consumer Staples.
+- Distribution Services → Industrials, with medical distribution → Health Care and food distribution → Consumer Staples.
+- Consumer Non-Durables → Consumer Staples, except apparel/footwear → Consumer Discretionary.
+- TradingView's generic Miscellaneous industries remain unmapped when no defensible assignment exists.
+
+Common explicit subsector hints include KBWB/KRE/KBE → banks, XBI/IBB → biotechnology, SMH/SOXX → semiconductors, ITA/PPA/XAR → aerospace and defense, GDX/GDXJ → precious metals, and COPX/XME → metals/mining industries.
+
+## Stock eligibility and ranking
+
+Drill into at most five selected industries. A stock must have:
+
+- USD pricing.
+- Market capitalization of at least $2 billion.
+- Price of at least $5.
+- Current daily dollar turnover of at least $20 million.
+- Monthly volatility outside the highest peer quintile.
+- Positive 1W and 1M performance with positive return acceleration.
+- No disqualifying one-day spike.
+
+Do not use relative volume. Rank qualified stocks using individual performance/acceleration (60%), inherited sector-industry confidence (30%), and history state (10%). Fundamentals are tie-breakers and risk flags, not primary gates.
+
+## Deterministic MCP contract
+
+Use `screen_daily_market_rotation` with:
+
+- `persist_history`: defaults to true; set false for dry runs.
+- `max_stock_candidates`: 1–5, default 5.
+
+The compact response contains sector flow summaries, broad rotations, subsector rotations, performance-led industries, stock candidates, rejection counts, lost confirmations, data-quality notes, and narration instructions. OpenClaw must preserve returned ordering and must not recompute or rerank results.
+
+Persist at most 20 US sessions under the `MARKET_ROTATION` LevelDB prefix. Do not persist unchanged/stale fingerprints. Detect new, strengthening, weakening, newly accelerating, and lost-confirmation states.
+
+## Brief and operations
+
+The full narration prompt, validation prompt, and suggested 6:30 a.m. Asia/Singapore Tuesday–Saturday schedule are in [openclaw-market-rotation.md](openclaw-market-rotation.md).
+
+The brief order is:
+
+1. 1M sector fund-flow landscape.
+2. Performance alignment and divergences.
+3. Broad-sector rotations.
+4. Independent subsector rotations.
+5. Performance-led opportunities.
+6. Zero to five stock candidates with evidence and invalidation conditions.
+7. Data-quality and exclusion notes.
+
+## Validation requirements
+
+- Unit tests cover exclusions, aggregation, breadth, acceleration, crosswalk exceptions, setup classification, spike rejection, history transitions, and no-candidate behavior.
+- The full Go suite and vet must pass.
+- Live validation uses `persist_history=false` and verifies a compact response without writing state.
+- Perform a completed post-close dry run before enabling scheduled delivery; intraday runs are diagnostic only.
+
+This feature is a quantitative screen, not a directive to trade.

--- a/docs/openclaw-market-rotation.md
+++ b/docs/openclaw-market-rotation.md
@@ -1,0 +1,44 @@
+# OpenClaw Daily Market-Rotation Brief
+
+The canonical strategy and scoring rationale live in [market-rotation-strategy.md](market-rotation-strategy.md). Load that document only for relevant market-rotation work.
+
+The `screen_daily_market_rotation` MCP tool performs every join, calculation, exclusion, classification, ranking, and history comparison in Go. OpenClaw should narrate its compact response without recomputing it.
+
+## Scheduled prompt
+
+```text
+Create today's US market-rotation brief.
+
+Call screen_daily_market_rotation with persist_history=true and max_stock_candidates=5. Treat the returned calculations, rankings, lane labels, and ordering as authoritative: do not recalculate, rerank, or fill a candidate quota.
+
+Write a concise brief in this exact order:
+1. 1M sector fund-flow landscape: explain where ETF capital is concentrating, which sectors have accelerating inflows, which remain in outflow but are improving, and which are worsening. Mention breadth and the largest ETF contributors or detractors when they materially explain a sector total.
+2. Market-performance alignment and divergences: identify where broad ETF performance confirms flow and where performance leads or conflicts with flow. Call out broad-versus-subsector disagreement.
+3. Broad-sector rotations.
+4. Independent subsector rotations.
+5. Performance-led, lower-confidence industries.
+6. Zero to five stock candidates, preserving the returned order. For each, state its lane, setup, evidence, primary risk, and supplied invalidation condition.
+7. Data-quality and exclusion notes.
+
+Mention newly accelerating, strengthening, weakening, and lost-confirmation states when returned.
+
+Use the phrase "ETF product flows" or "sector ETF flows". Never describe these values as direct stock-level institutional flows. If no stocks qualify, say so plainly. This is a quantitative screening brief, not a directive to trade.
+```
+
+## Validation prompt
+
+Use the scheduled prompt with `persist_history=false` for dry runs. The response must report `data_quality.persisted=false` and must not change LevelDB history.
+
+## Suggested schedule
+
+Run after the completed US session at 6:30 a.m. Singapore time, Tuesday through Saturday:
+
+```sh
+openclaw cron create "30 6 * * 2-6" \
+  "Create today's US market-rotation brief using screen_daily_market_rotation and the workspace market-rotation prompt." \
+  --name "US market rotation brief" \
+  --session isolated \
+  --tz Asia/Singapore
+```
+
+Add the desired OpenClaw `--agent`, delivery channel, and destination for the local installation before enabling delivery.

--- a/internal/server/mcp.go
+++ b/internal/server/mcp.go
@@ -12,7 +12,7 @@ import (
 	"github.com/mark3labs/mcp-go/server"
 )
 
-const mcpInstructions = "Routing rule: distinguish stock-market industries from sector ETFs. Stock industries and their underlying stocks provide overview and performance only; they do not provide fund flows. For requests mentioning sector fund flows, capital flows, inflows, or outflows, use the sector ETF fund-flow tool unless the user explicitly rejects ETFs. If the user asks for underlying-stock fund flows, explain that this dataset is unavailable. If intent remains unclear, ask whether they mean stock-market industries or sector ETFs. Fund-flow periods are 1M, 3M, 1Y, 3Y, and YTD."
+const mcpInstructions = "Routing rule: distinguish stock-market industries from sector ETFs. Stock industries and their underlying stocks provide overview and performance only; they do not provide fund flows. For raw requests mentioning sector fund flows, capital flows, inflows, or outflows, use the sector ETF fund-flow tool unless the user explicitly rejects ETFs. For a daily market brief, rotation screen, or ranked sector-to-stock drill-down, use screen_daily_market_rotation and preserve its precomputed order and classifications without recalculating. Describe its flows as ETF product flows, never direct stock-level institutional flows. If the user asks for underlying-stock fund flows, explain that this dataset is unavailable. If raw dataset intent remains unclear, ask whether they mean stock-market industries or sector ETFs. Fund-flow periods are 1M, 3M, 1Y, 3Y, and YTD."
 
 // MCPServer represents the MCP server instance
 type MCPServer struct {

--- a/internal/server/mcp_test.go
+++ b/internal/server/mcp_test.go
@@ -11,4 +11,6 @@ func TestMCPInstructionsDisambiguateStockIndustriesAndSectorETFs(t *testing.T) {
 	require.Contains(t, mcpInstructions, "sector ETF fund-flow tool")
 	require.Contains(t, mcpInstructions, "ask whether they mean stock-market industries or sector ETFs")
 	require.Contains(t, mcpInstructions, "1M, 3M, 1Y, 3Y, and YTD")
+	require.Contains(t, mcpInstructions, "screen_daily_market_rotation")
+	require.Contains(t, mcpInstructions, "never direct stock-level institutional flows")
 }

--- a/memory/market-rotation.md
+++ b/memory/market-rotation.md
@@ -1,0 +1,4 @@
+# Market-Rotation Memory
+
+The canonical strategy, scoring decisions, mappings, safety rules, and validation requirements live in [docs/market-rotation-strategy.md](../docs/market-rotation-strategy.md). Load that document only when a task concerns TradingView sector ETFs, fund flows, market rotation, stock drill-down, or the OpenClaw daily market brief. The operational prompt and schedule live in [docs/openclaw-market-rotation.md](../docs/openclaw-market-rotation.md).
+

--- a/pkg/mdata/market_rotation.go
+++ b/pkg/mdata/market_rotation.go
@@ -1,0 +1,1109 @@
+package mdata
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	"portfolio-manager/pkg/types"
+)
+
+const (
+	defaultMaxStockCandidates = 5
+	maxRotationHistory        = 20
+	maxIndustryDrilldowns     = 5
+	marketRotationSourceURL   = "https://www.tradingview.com/markets/etfs/funds-sector-etfs/"
+)
+
+var broadSectorETFs = map[string]string{
+	"XLC": "Communication services", "VOX": "Communication services",
+	"XLY": "Consumer discretionary", "VCR": "Consumer discretionary",
+	"XLP": "Consumer staples", "VDC": "Consumer staples",
+	"XLE": "Energy", "VDE": "Energy",
+	"XLF": "Financials", "VFH": "Financials",
+	"XLV": "Health care", "VHT": "Health care",
+	"XLI": "Industrials", "VIS": "Industrials",
+	"XLB": "Materials", "VAW": "Materials",
+	"XLRE": "Real estate", "VNQ": "Real estate",
+	"XLK": "Information technology", "VGT": "Information technology",
+	"XLU": "Utilities", "VPU": "Utilities",
+}
+
+// Subsector hints are deliberately explicit. Unmapped subsector ETFs remain visible in the
+// subsector lane but do not trigger an unrelated stock-industry drill-down.
+var subsectorIndustryHints = map[string][]string{
+	"KBWB": {"Major Banks", "Regional Banks"},
+	"KRE":  {"Regional Banks"},
+	"KBE":  {"Major Banks", "Regional Banks", "Savings Banks"},
+	"XBI":  {"Biotechnology"},
+	"IBB":  {"Biotechnology"},
+	"SMH":  {"Semiconductors"},
+	"SOXX": {"Semiconductors"},
+	"IGV":  {"Packaged Software"},
+	"ITA":  {"Aerospace & Defense"},
+	"PPA":  {"Aerospace & Defense"},
+	"XAR":  {"Aerospace & Defense"},
+	"GDX":  {"Precious Metals"},
+	"GDXJ": {"Precious Metals"},
+	"COPX": {"Other Metals/Minerals"},
+	"XME":  {"Steel", "Aluminum", "Other Metals/Minerals"},
+}
+
+type joinedSectorETF struct {
+	overview    types.ETFSectorOverview
+	performance types.ETFFundFlowPerformance
+	flows       types.ETFFundFlows
+	class       string
+	sector      string
+	flow1Pct    float64
+	flowPrior2  float64
+	flowAccel   float64
+	perf        types.RotationPerformance
+}
+
+type sectorAccumulator struct {
+	sector     string
+	etfs       []joinedSectorETF
+	broad      []joinedSectorETF
+	subsector  []joinedSectorETF
+	aum        float64
+	flow1      float64
+	flow3      float64
+	positive   int
+	broadFlow1 float64
+	broadFlow3 float64
+	broadAUM   float64
+	subFlow1   float64
+	subFlow3   float64
+	subAUM     float64
+}
+
+type marketRotationSnapshot struct {
+	Fingerprint string                    `json:"fingerprint"`
+	Brief       types.MarketRotationBrief `json:"brief"`
+}
+
+type industryAnalysis struct {
+	signal     types.IndustryRotationSignal
+	confidence float64
+}
+
+// ScreenDailyMarketRotation builds the deterministic payload consumed by OpenClaw.
+func (m *Manager) ScreenDailyMarketRotation(options MarketRotationOptions) (*types.MarketRotationBrief, error) {
+	if options.MaxStockCandidates <= 0 || options.MaxStockCandidates > defaultMaxStockCandidates {
+		options.MaxStockCandidates = defaultMaxStockCandidates
+	}
+	return screenDailyMarketRotation(m, m.db, options, time.Now())
+}
+
+func screenDailyMarketRotation(screener MarketDataScreener, db databaseStore, options MarketRotationOptions, now time.Time) (*types.MarketRotationBrief, error) {
+	overview, err := screener.FetchETFSectorOverview()
+	if err != nil {
+		return nil, fmt.Errorf("fetch sector ETF overview: %w", err)
+	}
+	performance, err := screener.FetchETFSectorPerformance()
+	if err != nil {
+		return nil, fmt.Errorf("fetch sector ETF performance: %w", err)
+	}
+	flows, err := screener.FetchETFSectorFundFlows()
+	if err != nil {
+		return nil, fmt.Errorf("fetch sector ETF fund flows: %w", err)
+	}
+	industryOverview, err := screener.FetchUSAIndustryOverview()
+	if err != nil {
+		return nil, fmt.Errorf("fetch industry overview: %w", err)
+	}
+	industryPerformance, err := screener.FetchUSAIndustryPerformance()
+	if err != nil {
+		return nil, fmt.Errorf("fetch industry performance: %w", err)
+	}
+
+	joined, exclusions := joinAndFilterSectorETFs(overview, performance, flows)
+	sectorFlows := aggregateSectorFlows(joined)
+	previous, historyErr := loadLatestRotationSnapshot(db)
+	if historyErr != nil && options.PersistHistory {
+		return nil, fmt.Errorf("load market rotation history: %w", historyErr)
+	}
+	applySectorFlowTransitions(sectorFlows, previous)
+	broadSignals := buildBroadSectorSignals(sectorFlows, previous)
+	subsectorSignals := buildSubsectorSignals(joined, previous)
+	industries, unmapped := buildIndustrySignals(industryOverview, industryPerformance, sectorFlows, broadSignals, subsectorSignals, previous)
+
+	rejected := make(map[string]int)
+	stocks, err := buildStockCandidates(screener, industries, previous, options.MaxStockCandidates, rejected)
+	if err != nil {
+		return nil, err
+	}
+
+	newYork, tzErr := time.LoadLocation("America/New_York")
+	if tzErr != nil {
+		newYork = time.FixedZone("ET", -5*60*60)
+	}
+	brief := &types.MarketRotationBrief{
+		AsOf:                     now.UTC().Format(time.RFC3339),
+		USSessionDate:            now.In(newYork).Format("2006-01-02"),
+		MethodologyVersion:       types.MarketRotationMethodologyVersion,
+		SectorFundFlows:          sectorFlows,
+		BroadSectorRotations:     broadSignals,
+		SubsectorRotations:       subsectorSignals,
+		PerformanceLedIndustries: topIndustrySignals(industries, 10),
+		StockCandidates:          stocks,
+		RejectedStockCounts:      rejected,
+		DataQuality: types.MarketRotationDataQuality{
+			Source:                "TradingView sector ETFs and USA stock industries",
+			SourceURL:             marketRotationSourceURL,
+			InputETFCount:         len(overview),
+			EligibleETFCount:      len(joined),
+			ExcludedETFCount:      len(overview) - len(joined),
+			ExclusionsByReason:    exclusions,
+			UnmappedIndustryCount: unmapped,
+		},
+		BriefInstructions: []string{
+			"Use the precomputed values and rankings exactly; do not recalculate or reorder them.",
+			"Start with the 1M sector fund-flow landscape, then performance alignment and divergences.",
+			"Cover broad-sector rotations, subsector rotations, performance-led opportunities, and zero to five stock candidates.",
+			"Describe ETF product flows, never direct stock-level institutional flows.",
+			"End with data-quality, exclusion, and invalidation notes.",
+		},
+	}
+	brief.LostConfirmations = detectLostConfirmations(previous, brief)
+
+	fingerprint, err := rotationFingerprint(brief)
+	if err != nil {
+		return nil, err
+	}
+	if previous != nil && previous.Fingerprint == fingerprint {
+		brief.DataQuality.Stale = true
+		brief.DataQuality.Warnings = append(brief.DataQuality.Warnings, "The deterministic input fingerprint is unchanged from the latest stored session.")
+	}
+	if options.PersistHistory {
+		if db == nil {
+			return nil, errors.New("market rotation history persistence requires a database")
+		}
+		if !brief.DataQuality.Stale {
+			if err := persistRotationSnapshot(db, *brief, fingerprint); err != nil {
+				return nil, err
+			}
+			brief.DataQuality.Persisted = true
+		}
+	}
+	return brief, nil
+}
+
+type databaseStore interface {
+	Get(key string, value interface{}) error
+	Put(key string, value interface{}) error
+	Delete(key string) error
+	GetAllKeysWithPrefix(prefix string) ([]string, error)
+}
+
+func joinAndFilterSectorETFs(overviews []types.ETFSectorOverview, performances []types.ETFFundFlowPerformance, flows []types.ETFFundFlows) ([]joinedSectorETF, map[string]int) {
+	perfByID := make(map[string]types.ETFFundFlowPerformance, len(performances))
+	flowByID := make(map[string]types.ETFFundFlows, len(flows))
+	for _, row := range performances {
+		perfByID[row.ID] = row
+	}
+	for _, row := range flows {
+		flowByID[row.ID] = row
+	}
+	exclusions := make(map[string]int)
+	result := make([]joinedSectorETF, 0, len(overviews))
+	for _, row := range overviews {
+		perf, perfOK := perfByID[row.ID]
+		flow, flowOK := flowByID[row.ID]
+		if !perfOK || !flowOK {
+			exclusions["missing_joined_tab"]++
+			continue
+		}
+		reason := exclusionReason(row, flow)
+		if reason != "" {
+			exclusions[reason]++
+			continue
+		}
+		if row.AssetsUnderManagement == nil || *row.AssetsUnderManagement <= 0 || flow.OneMonth == nil || flow.ThreeMonths == nil || !completePerformance(perf) {
+			exclusions["missing_required_value"]++
+			continue
+		}
+		class := "subsector"
+		sector := canonicalETFSector(row.Focus)
+		if broadSector, ok := broadSectorETFs[strings.ToUpper(row.Ticker)]; ok {
+			class = "broad"
+			sector = broadSector
+		}
+		if sector == "" {
+			exclusions["unsupported_focus"]++
+			continue
+		}
+		aum := *row.AssetsUnderManagement
+		flow1 := *flow.OneMonth
+		flow3 := *flow.ThreeMonths
+		result = append(result, joinedSectorETF{
+			overview: row, performance: perf, flows: flow, class: class, sector: sector,
+			flow1Pct:   100 * flow1 / aum,
+			flowPrior2: 100 * ((flow3 - flow1) / 2) / aum,
+			flowAccel:  100 * (flow1 - ((flow3 - flow1) / 2)) / aum,
+			perf:       rotationPerformance(perf.Change, perf.OneWeek, perf.OneMonth, perf.ThreeMonths, perf.SixMonths, perf.OneYear),
+		})
+	}
+	return result, exclusions
+}
+
+func exclusionReason(row types.ETFSectorOverview, flow types.ETFFundFlows) string {
+	if !isUSExchange(row.Exchange) {
+		return "foreign_listing"
+	}
+	if row.AUMCurrency != "USD" || row.Currency != "USD" || flow.Currency != "USD" {
+		return "non_usd"
+	}
+	if !strings.EqualFold(row.AssetClass, "Equity") {
+		return "non_equity"
+	}
+	if strings.EqualFold(row.Focus, "Theme") {
+		return "thematic"
+	}
+	name := strings.ToLower(row.Fund + " " + row.Ticker)
+	for _, token := range []string{" leveraged", " inverse", " ultra", "ultrapro", " bull ", " bear ", "daily ", " daily", " 2x", " 3x", "-2x", "-3x", "single-stock", "single stock"} {
+		if strings.Contains(name, token) {
+			return "leveraged_inverse_or_single_stock"
+		}
+	}
+	return ""
+}
+
+func isUSExchange(exchange string) bool {
+	switch strings.ToUpper(strings.TrimSpace(exchange)) {
+	case "AMEX", "NASDAQ", "NYSE", "NYSEARCA", "ARCA", "CBOE", "BATS":
+		return true
+	default:
+		return false
+	}
+}
+
+func canonicalETFSector(focus string) string {
+	for _, sector := range []string{"Communication services", "Consumer discretionary", "Consumer staples", "Energy", "Financials", "Health care", "Industrials", "Information technology", "Materials", "Real estate", "Utilities"} {
+		if strings.EqualFold(focus, sector) {
+			return sector
+		}
+	}
+	return ""
+}
+
+func aggregateSectorFlows(etfs []joinedSectorETF) []types.SectorFundFlowSummary {
+	groups := make(map[string]*sectorAccumulator)
+	for _, etf := range etfs {
+		group := groups[etf.sector]
+		if group == nil {
+			group = &sectorAccumulator{sector: etf.sector}
+			groups[etf.sector] = group
+		}
+		group.etfs = append(group.etfs, etf)
+		group.aum += *etf.overview.AssetsUnderManagement
+		group.flow1 += *etf.flows.OneMonth
+		group.flow3 += *etf.flows.ThreeMonths
+		if *etf.flows.OneMonth > 0 {
+			group.positive++
+		}
+		if etf.class == "broad" {
+			group.broad = append(group.broad, etf)
+			group.broadFlow1 += *etf.flows.OneMonth
+			group.broadFlow3 += *etf.flows.ThreeMonths
+			group.broadAUM += *etf.overview.AssetsUnderManagement
+		} else {
+			group.subsector = append(group.subsector, etf)
+			group.subFlow1 += *etf.flows.OneMonth
+			group.subFlow3 += *etf.flows.ThreeMonths
+			group.subAUM += *etf.overview.AssetsUnderManagement
+		}
+	}
+	result := make([]types.SectorFundFlowSummary, 0, len(groups))
+	for _, group := range groups {
+		priorFlow := (group.flow3 - group.flow1) / 2
+		broadPriorFlow := (group.broadFlow3 - group.broadFlow1) / 2
+		subPriorFlow := (group.subFlow3 - group.subFlow1) / 2
+		flowPct := safePercent(group.flow1, group.aum)
+		priorPct := safePercent(priorFlow, group.aum)
+		broadPerf := weightedPerformance(group.broad)
+		result = append(result, types.SectorFundFlowSummary{
+			Sector: group.sector, ETFCount: len(group.etfs), BroadETFCount: len(group.broad), SubsectorETFCount: len(group.subsector),
+			PositiveFlowETFCount: group.positive, PositiveFlowBreadthPercent: round(safePercent(float64(group.positive), float64(len(group.etfs))), 1),
+			CombinedAUMUSD: round(group.aum, 0), OneMonthFlowUSD: round(group.flow1, 0), ThreeMonthFlowUSD: round(group.flow3, 0),
+			OneMonthFlowPercentAUM: round(flowPct, 3), PriorTwoMonthMonthlyFlowUSD: round(priorFlow, 0),
+			PriorTwoMonthMonthlyPercentAUM: round(priorPct, 3), FlowAccelerationPercentAUM: round(flowPct-priorPct, 3),
+			BroadOneMonthFlowUSD: round(group.broadFlow1, 0), SubsectorOneMonthFlowUSD: round(group.subFlow1, 0),
+			BroadFlowAccelerationPercentAUM:     round(safePercent(group.broadFlow1-broadPriorFlow, group.broadAUM), 3),
+			SubsectorFlowAccelerationPercentAUM: round(safePercent(group.subFlow1-subPriorFlow, group.subAUM), 3),
+			BroadSubsectorRelationship:          broadSubsectorRelationship(group.broad, group.subsector, group.broadFlow1, group.subFlow1),
+			FlowTrend:                           flowTrend(group.flow1, priorFlow), BroadPerformance: broadPerf,
+			PerformanceFlowAlignment: performanceFlowAlignment(group.flow1, broadPerf),
+			LargestContributors:      contributions(group.etfs, true), LargestDetractors: contributions(group.etfs, false),
+		})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].OneMonthFlowPercentAUM > result[j].OneMonthFlowPercentAUM })
+	return result
+}
+
+func applySectorFlowTransitions(rows []types.SectorFundFlowSummary, previous *marketRotationSnapshot) {
+	if previous == nil {
+		for i := range rows {
+			rows[i].HistoryTransition = "baseline"
+		}
+		return
+	}
+	prior := make(map[string]types.SectorFundFlowSummary, len(previous.Brief.SectorFundFlows))
+	for _, row := range previous.Brief.SectorFundFlows {
+		prior[row.Sector] = row
+	}
+	for i := range rows {
+		old, ok := prior[rows[i].Sector]
+		if !ok {
+			rows[i].HistoryTransition = "new"
+			continue
+		}
+		current := rows[i].FlowAccelerationPercentAUM
+		before := old.FlowAccelerationPercentAUM
+		switch {
+		case before <= 0 && current > 0:
+			rows[i].HistoryTransition = "newly_accelerating"
+		case current >= before+0.25:
+			rows[i].HistoryTransition = "strengthening"
+		case current <= before-0.25:
+			rows[i].HistoryTransition = "weakening"
+		default:
+			rows[i].HistoryTransition = "unchanged"
+		}
+	}
+}
+
+func contributions(etfs []joinedSectorETF, descending bool) []types.ETFContribution {
+	rows := make([]joinedSectorETF, 0, len(etfs))
+	for _, row := range etfs {
+		if descending && *row.flows.OneMonth > 0 {
+			rows = append(rows, row)
+		}
+		if !descending && *row.flows.OneMonth < 0 {
+			rows = append(rows, row)
+		}
+	}
+	sort.Slice(rows, func(i, j int) bool {
+		if descending {
+			return *rows[i].flows.OneMonth > *rows[j].flows.OneMonth
+		}
+		return *rows[i].flows.OneMonth < *rows[j].flows.OneMonth
+	})
+	if len(rows) > 3 {
+		rows = rows[:3]
+	}
+	result := make([]types.ETFContribution, 0, len(rows))
+	for _, row := range rows {
+		result = append(result, types.ETFContribution{Ticker: row.overview.Ticker, Fund: row.overview.Fund, Classification: row.class, OneMonthFlow: round(*row.flows.OneMonth, 0)})
+	}
+	return result
+}
+
+func broadSubsectorRelationship(broad, subsector []joinedSectorETF, broadFlow, subsectorFlow float64) string {
+	if len(broad) == 0 || len(subsector) == 0 {
+		return "insufficient_comparison"
+	}
+	if broadFlow >= 0 && subsectorFlow >= 0 {
+		return "aligned_inflow"
+	}
+	if broadFlow < 0 && subsectorFlow < 0 {
+		return "aligned_outflow"
+	}
+	if broadFlow >= 0 {
+		return "broad_inflow_subsector_outflow"
+	}
+	return "broad_outflow_subsector_inflow"
+}
+
+func flowTrend(current, prior float64) string {
+	switch {
+	case current >= 0 && current >= prior:
+		return "accelerating_inflow"
+	case current >= 0:
+		return "decelerating_inflow"
+	case current > prior:
+		return "improving_outflow"
+	default:
+		return "worsening_outflow"
+	}
+}
+
+func performanceFlowAlignment(flow float64, perf types.RotationPerformance) string {
+	performancePositive := perf.OneMonth > 0 && perf.Acceleration > 0
+	if flow > 0 && performancePositive {
+		return "aligned_positive"
+	}
+	if flow < 0 && !performancePositive {
+		return "aligned_negative"
+	}
+	if performancePositive {
+		return "performance_leads_flow"
+	}
+	return "flow_leads_performance"
+}
+
+func weightedPerformance(etfs []joinedSectorETF) types.RotationPerformance {
+	var result types.RotationPerformance
+	var total float64
+	for _, etf := range etfs {
+		weight := *etf.overview.AssetsUnderManagement
+		total += weight
+		result.OneDay += etf.perf.OneDay * weight
+		result.OneWeek += etf.perf.OneWeek * weight
+		result.OneMonth += etf.perf.OneMonth * weight
+		result.ThreeMonths += etf.perf.ThreeMonths * weight
+		result.SixMonths += etf.perf.SixMonths * weight
+		result.OneYear += etf.perf.OneYear * weight
+	}
+	if total == 0 {
+		return result
+	}
+	result.OneDay /= total
+	result.OneWeek /= total
+	result.OneMonth /= total
+	result.ThreeMonths /= total
+	result.SixMonths /= total
+	result.OneYear /= total
+	result.PriorTwoMonthPace = priorTwoMonthReturnPace(result.OneMonth, result.ThreeMonths)
+	result.Acceleration = result.OneMonth - result.PriorTwoMonthPace
+	return roundedPerformance(result)
+}
+
+func buildBroadSectorSignals(flows []types.SectorFundFlowSummary, previous *marketRotationSnapshot) []types.SectorRotationSignal {
+	accels, sixMonths, threeMonths := make([]float64, 0, len(flows)), make([]float64, 0, len(flows)), make([]float64, 0, len(flows))
+	for _, row := range flows {
+		accels = append(accels, row.BroadPerformance.Acceleration)
+		sixMonths = append(sixMonths, row.BroadPerformance.SixMonths)
+		threeMonths = append(threeMonths, row.BroadPerformance.ThreeMonths)
+	}
+	result := make([]types.SectorRotationSignal, 0)
+	for _, row := range flows {
+		perf := row.BroadPerformance
+		setup := setupType(perf, percentileRank(sixMonths, perf.SixMonths), percentileRank(accels, perf.Acceleration), percentileRank(threeMonths, perf.ThreeMonths))
+		aligned := row.BroadOneMonthFlowUSD > 0 && row.BroadFlowAccelerationPercentAUM > 0 && perf.OneWeek > 0 && perf.OneMonth > 0 && perf.Acceleration > 0
+		if !aligned || setup == "unconfirmed" {
+			continue
+		}
+		score := 100 * (0.35*percentileRank(flowMetric(flows, func(x types.SectorFundFlowSummary) float64 { return x.OneMonthFlowPercentAUM }), row.OneMonthFlowPercentAUM) +
+			0.25*percentileRank(flowMetric(flows, func(x types.SectorFundFlowSummary) float64 { return x.FlowAccelerationPercentAUM }), row.FlowAccelerationPercentAUM) +
+			0.40*percentileRank(accels, perf.Acceleration))
+		result = append(result, types.SectorRotationSignal{Sector: row.Sector, Setup: setup, Score: round(score, 1), Transition: sectorTransition(previous, row.Sector, score), FlowTrend: row.FlowTrend, Performance: perf})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Score > result[j].Score })
+	return result
+}
+
+func buildSubsectorSignals(etfs []joinedSectorETF, previous *marketRotationSnapshot) []types.SubsectorRotationSignal {
+	accels, sixMonths, threeMonths := make([]float64, 0), make([]float64, 0), make([]float64, 0)
+	for _, row := range etfs {
+		if row.class == "subsector" {
+			accels = append(accels, row.perf.Acceleration)
+			sixMonths = append(sixMonths, row.perf.SixMonths)
+			threeMonths = append(threeMonths, row.perf.ThreeMonths)
+		}
+	}
+	result := make([]types.SubsectorRotationSignal, 0)
+	for _, row := range etfs {
+		if row.class != "subsector" || *row.flows.OneMonth <= 0 || row.flowAccel <= 0 || row.perf.OneWeek <= 0 || row.perf.OneMonth <= 0 || row.perf.Acceleration <= 0 {
+			continue
+		}
+		setup := setupType(row.perf, percentileRank(sixMonths, row.perf.SixMonths), percentileRank(accels, row.perf.Acceleration), percentileRank(threeMonths, row.perf.ThreeMonths))
+		if setup == "unconfirmed" {
+			continue
+		}
+		score := 100 * (0.35*percentileRank(etfMetric(etfs, func(x joinedSectorETF) float64 { return x.flow1Pct }), row.flow1Pct) + 0.25*percentileRank(etfMetric(etfs, func(x joinedSectorETF) float64 { return x.flowAccel }), row.flowAccel) + 0.40*percentileRank(accels, row.perf.Acceleration))
+		result = append(result, types.SubsectorRotationSignal{
+			Ticker: row.overview.Ticker, Fund: row.overview.Fund, Sector: row.sector, MappedIndustries: subsectorIndustryHints[strings.ToUpper(row.overview.Ticker)],
+			Setup: setup, Score: round(score, 1), Transition: subsectorTransition(previous, row.overview.Ticker, score), OneMonthFlowUSD: round(*row.flows.OneMonth, 0),
+			FlowPercentAUM: round(row.flow1Pct, 3), FlowAcceleration: round(row.flowAccel, 3), Performance: row.perf,
+		})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Score > result[j].Score })
+	if len(result) > 8 {
+		result = result[:8]
+	}
+	return result
+}
+
+func buildIndustrySignals(overviews []types.USAIndustryOverview, performances []types.USAIndustryPerformance, sectorFlows []types.SectorFundFlowSummary, broad []types.SectorRotationSignal, subsectors []types.SubsectorRotationSignal, previous *marketRotationSnapshot) ([]industryAnalysis, int) {
+	overviewByID := make(map[string]types.USAIndustryOverview, len(overviews))
+	for _, row := range overviews {
+		overviewByID[row.ID] = row
+	}
+	flowBySector := make(map[string]types.SectorFundFlowSummary, len(sectorFlows))
+	for _, row := range sectorFlows {
+		flowBySector[row.Sector] = row
+	}
+	broadBySector := make(map[string]types.SectorRotationSignal, len(broad))
+	for _, row := range broad {
+		broadBySector[row.Sector] = row
+	}
+	hinted := make(map[string]types.SubsectorRotationSignal)
+	for _, row := range subsectors {
+		for _, industry := range row.MappedIndustries {
+			if existing, ok := hinted[industry]; !ok || row.Score > existing.Score {
+				hinted[industry] = row
+			}
+		}
+	}
+
+	accels, sixMonths, threeMonths, days, weeks, months := make([]float64, 0), make([]float64, 0), make([]float64, 0), make([]float64, 0), make([]float64, 0), make([]float64, 0)
+	joined := make([]struct {
+		overview types.USAIndustryOverview
+		perf     types.USAIndustryPerformance
+		shape    types.RotationPerformance
+	}, 0, len(performances))
+	unmapped := 0
+	for _, perf := range performances {
+		overview, ok := overviewByID[perf.ID]
+		if !ok || !completeIndustryPerformance(perf) {
+			continue
+		}
+		if _, ok := mapIndustryToETFSector(overview.Sector, overview.Industry); !ok {
+			unmapped++
+			continue
+		}
+		shape := rotationPerformance(perf.Change, perf.OneWeek, perf.OneMonth, perf.ThreeMonths, perf.SixMonths, perf.OneYear)
+		joined = append(joined, struct {
+			overview types.USAIndustryOverview
+			perf     types.USAIndustryPerformance
+			shape    types.RotationPerformance
+		}{overview, perf, shape})
+		accels, sixMonths, threeMonths, days = append(accels, shape.Acceleration), append(sixMonths, shape.SixMonths), append(threeMonths, shape.ThreeMonths), append(days, shape.OneDay)
+		weeks, months = append(weeks, shape.OneWeek), append(months, shape.OneMonth)
+	}
+
+	result := make([]industryAnalysis, 0)
+	for _, row := range joined {
+		sector, _ := mapIndustryToETFSector(row.overview.Sector, row.overview.Industry)
+		setup := setupType(row.shape, percentileRank(sixMonths, row.shape.SixMonths), percentileRank(accels, row.shape.Acceleration), percentileRank(threeMonths, row.shape.ThreeMonths))
+		spike := oneDaySpike(row.shape, percentileRank(days, row.shape.OneDay))
+		if row.shape.OneWeek <= 0 || row.shape.OneMonth <= 0 || row.shape.Acceleration <= 0 || spike || setup == "unconfirmed" {
+			continue
+		}
+		lane := "performance_led"
+		confidence := 0.60
+		alignmentScore := 0.60
+		if broadSignal, ok := broadBySector[sector]; ok {
+			lane, confidence, alignmentScore = "broad_sector_confirmed", 1.0, broadSignal.Score/100
+		}
+		if hint, ok := hinted[row.overview.Industry]; ok && confidence < 0.85 {
+			lane, confidence, alignmentScore = "subsector_rotation", 0.85, hint.Score/100
+		}
+		if flow, ok := flowBySector[sector]; ok && flow.PerformanceFlowAlignment == "performance_leads_flow" && lane == "performance_led" {
+			confidence = 0.55
+		}
+		score := 100 * (0.60*(0.50*percentileRank(accels, row.shape.Acceleration)+0.25*percentileRank(weeks, row.shape.OneWeek)+0.25*percentileRank(months, row.shape.OneMonth)) + 0.40*alignmentScore)
+		result = append(result, industryAnalysis{signal: types.IndustryRotationSignal{
+			ID: row.overview.ID, Industry: row.overview.Industry, StockSector: row.overview.Sector, ETFSector: sector,
+			Lane: lane, Setup: setup, Score: round(score, 1), Transition: industryTransition(previous, row.overview.Industry, score), Performance: row.shape,
+		}, confidence: confidence})
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].signal.Score > result[j].signal.Score })
+	return result, unmapped
+}
+
+func buildStockCandidates(screener MarketDataScreener, industries []industryAnalysis, previous *marketRotationSnapshot, maxCandidates int, rejected map[string]int) ([]types.StockRotationCandidate, error) {
+	selected := selectIndustryDrilldowns(industries)
+	all := make([]types.StockRotationCandidate, 0)
+	for _, industry := range selected {
+		overviews, err := screener.FetchUSAIndustryStocksOverview(industry.signal.Industry)
+		if err != nil {
+			return nil, fmt.Errorf("fetch %s stock overview: %w", industry.signal.Industry, err)
+		}
+		performances, err := screener.FetchUSAIndustryStocksPerformance(industry.signal.Industry)
+		if err != nil {
+			return nil, fmt.Errorf("fetch %s stock performance: %w", industry.signal.Industry, err)
+		}
+		all = append(all, scoreIndustryStocks(industry, overviews, performances, previous, rejected)...)
+	}
+	sort.Slice(all, func(i, j int) bool { return all[i].Score > all[j].Score })
+	if len(all) > maxCandidates {
+		all = all[:maxCandidates]
+	}
+	return all, nil
+}
+
+func scoreIndustryStocks(industry industryAnalysis, overviews []types.USAIndustryStockOverview, performances []types.USAIndustryStockPerformance, previous *marketRotationSnapshot, rejected map[string]int) []types.StockRotationCandidate {
+	overviewByID := make(map[string]types.USAIndustryStockOverview, len(overviews))
+	for _, row := range overviews {
+		overviewByID[row.ID] = row
+	}
+	type joinedStock struct {
+		overview types.USAIndustryStockOverview
+		shape    types.RotationPerformance
+		vol      float64
+		turnover float64
+	}
+	base := make([]joinedStock, 0)
+	for _, perf := range performances {
+		overview, ok := overviewByID[perf.ID]
+		if !ok || !completeStockPerformance(perf) || overview.MarketCap == nil || overview.Price == nil || overview.Volume == nil {
+			rejected["missing_required_value"]++
+			continue
+		}
+		turnover := *overview.Price * *overview.Volume
+		switch {
+		case overview.Currency != "USD":
+			rejected["non_usd_stock"]++
+		case *overview.MarketCap < 2_000_000_000:
+			rejected["market_cap_below_2b"]++
+		case *overview.Price < 5:
+			rejected["price_below_5"]++
+		case turnover < 20_000_000:
+			rejected["turnover_below_20m"]++
+		default:
+			base = append(base, joinedStock{overview: overview, shape: rotationPerformance(perf.Change, perf.OneWeek, perf.OneMonth, perf.ThreeMonths, perf.SixMonths, perf.OneYear), vol: *perf.VolatilityOneMonth, turnover: turnover})
+		}
+	}
+	if len(base) == 0 {
+		return nil
+	}
+	vols, accels, sixMonths, threeMonths, days, weeks, months := make([]float64, 0), make([]float64, 0), make([]float64, 0), make([]float64, 0), make([]float64, 0), make([]float64, 0), make([]float64, 0)
+	for _, row := range base {
+		vols, accels, sixMonths = append(vols, row.vol), append(accels, row.shape.Acceleration), append(sixMonths, row.shape.SixMonths)
+		threeMonths, days, weeks, months = append(threeMonths, row.shape.ThreeMonths), append(days, row.shape.OneDay), append(weeks, row.shape.OneWeek), append(months, row.shape.OneMonth)
+	}
+	result := make([]types.StockRotationCandidate, 0)
+	for _, row := range base {
+		if percentileRank(vols, row.vol) > 0.80 {
+			rejected["highest_volatility_quintile"]++
+			continue
+		}
+		setup := setupType(row.shape, percentileRank(sixMonths, row.shape.SixMonths), percentileRank(accels, row.shape.Acceleration), percentileRank(threeMonths, row.shape.ThreeMonths))
+		if row.shape.OneWeek <= 0 || row.shape.OneMonth <= 0 || row.shape.Acceleration <= 0 || setup == "unconfirmed" {
+			rejected["unconfirmed_return_shape"]++
+			continue
+		}
+		if oneDaySpike(row.shape, percentileRank(days, row.shape.OneDay)) {
+			rejected["one_day_spike"]++
+			continue
+		}
+		performanceScore := 0.25*percentileRank(weeks, row.shape.OneWeek) + 0.25*percentileRank(months, row.shape.OneMonth) + 0.50*percentileRank(accels, row.shape.Acceleration)
+		score := 100 * (0.60*performanceScore + 0.30*industry.confidence + 0.10*historyScore(previous, row.overview.Ticker))
+		result = append(result, types.StockRotationCandidate{
+			Ticker: row.overview.Ticker, Company: row.overview.Company, Industry: industry.signal.Industry, ETFSector: industry.signal.ETFSector,
+			Lane: industry.signal.Lane, Setup: setup, Score: round(score, 1), Transition: stockTransition(previous, row.overview.Ticker, score),
+			MarketCapUSD: round(*row.overview.MarketCap, 0), DailyTurnoverUSD: round(row.turnover, 0), MonthlyVolatility: round(row.vol, 3),
+			EPSGrowthYoY: row.overview.EPSDilutedGrowthYoYTTM, AnalystRating: row.overview.AnalystRating, Performance: row.shape,
+			Invalidation: "The setup loses confirmation if 1W or 1M performance turns non-positive, return acceleration turns negative, or its sector/industry lane loses confirmation.",
+		})
+	}
+	return result
+}
+
+func selectIndustryDrilldowns(industries []industryAnalysis) []industryAnalysis {
+	result := make([]industryAnalysis, 0, maxIndustryDrilldowns)
+	lanes := []string{"broad_sector_confirmed", "subsector_rotation", "performance_led"}
+	seen := make(map[string]bool)
+	for _, lane := range lanes {
+		for _, row := range industries {
+			if row.signal.Lane == lane && !seen[row.signal.Industry] {
+				result = append(result, row)
+				seen[row.signal.Industry] = true
+				break
+			}
+		}
+	}
+	for _, row := range industries {
+		if len(result) >= maxIndustryDrilldowns {
+			break
+		}
+		if !seen[row.signal.Industry] {
+			result = append(result, row)
+			seen[row.signal.Industry] = true
+		}
+	}
+	return result
+}
+
+func topIndustrySignals(industries []industryAnalysis, limit int) []types.IndustryRotationSignal {
+	if len(industries) < limit {
+		limit = len(industries)
+	}
+	result := make([]types.IndustryRotationSignal, 0, limit)
+	for _, row := range industries[:limit] {
+		result = append(result, row.signal)
+	}
+	return result
+}
+
+func mapIndustryToETFSector(stockSector, industry string) (string, bool) {
+	stockSector = strings.ToLower(strings.TrimSpace(stockSector))
+	industryLower := strings.ToLower(strings.TrimSpace(industry))
+	containsAny := func(values ...string) bool {
+		for _, value := range values {
+			if strings.Contains(industryLower, value) {
+				return true
+			}
+		}
+		return false
+	}
+	switch stockSector {
+	case "communications":
+		return "Communication services", true
+	case "energy minerals":
+		return "Energy", true
+	case "health services", "health technology":
+		return "Health care", true
+	case "non-energy minerals":
+		return "Materials", true
+	case "transportation":
+		return "Industrials", true
+	case "utilities":
+		return "Utilities", true
+	case "finance":
+		if containsAny("real estate investment trust", "real estate development") {
+			return "Real estate", true
+		}
+		return "Financials", true
+	case "electronic technology":
+		if containsAny("aerospace & defense") {
+			return "Industrials", true
+		}
+		return "Information technology", true
+	case "technology services":
+		if containsAny("internet software/services") {
+			return "Communication services", true
+		}
+		return "Information technology", true
+	case "industrial services":
+		if containsAny("oil & gas pipeline", "contract drilling", "oilfield services") {
+			return "Energy", true
+		}
+		return "Industrials", true
+	case "process industries":
+		if containsAny("agricultural commodities") {
+			return "Consumer staples", true
+		}
+		return "Materials", true
+	case "consumer non-durables":
+		if containsAny("apparel/footwear") {
+			return "Consumer discretionary", true
+		}
+		return "Consumer staples", true
+	case "consumer durables":
+		return "Consumer discretionary", true
+	case "consumer services":
+		if containsAny("movies/entertainment", "media conglomerates", "cable/satellite", "broadcasting", "publishing") {
+			return "Communication services", true
+		}
+		return "Consumer discretionary", true
+	case "retail trade":
+		if containsAny("food retail", "drugstore", "discount stores") {
+			return "Consumer staples", true
+		}
+		return "Consumer discretionary", true
+	case "distribution services":
+		if containsAny("medical distributors") {
+			return "Health care", true
+		}
+		if containsAny("food distributors") {
+			return "Consumer staples", true
+		}
+		return "Industrials", true
+	case "commercial services":
+		if containsAny("advertising/marketing") {
+			return "Communication services", true
+		}
+		return "Industrials", true
+	case "producer manufacturing":
+		if containsAny("auto parts") {
+			return "Consumer discretionary", true
+		}
+		return "Industrials", true
+	default:
+		return "", false
+	}
+}
+
+func setupType(perf types.RotationPerformance, sixMonthPercentile, accelerationPercentile, threeMonthPercentile float64) string {
+	if perf.SixMonths <= 0 || perf.OneYear <= 0 {
+		return "recovery"
+	}
+	if sixMonthPercentile <= 0.60 && accelerationPercentile >= 0.75 {
+		return "ignition"
+	}
+	if threeMonthPercentile >= 0.75 && sixMonthPercentile >= 0.75 {
+		return "continuation"
+	}
+	return "unconfirmed"
+}
+
+func oneDaySpike(perf types.RotationPerformance, dayPercentile float64) bool {
+	return perf.OneDay > 0 && perf.OneWeek > 0 && perf.OneDay/perf.OneWeek > 0.70 && dayPercentile >= 0.90
+}
+
+func rotationPerformance(day, week, month, three, six, year *float64) types.RotationPerformance {
+	result := types.RotationPerformance{OneDay: value(day), OneWeek: value(week), OneMonth: value(month), ThreeMonths: value(three), SixMonths: value(six), OneYear: value(year)}
+	result.PriorTwoMonthPace = priorTwoMonthReturnPace(result.OneMonth, result.ThreeMonths)
+	result.Acceleration = result.OneMonth - result.PriorTwoMonthPace
+	return roundedPerformance(result)
+}
+
+func roundedPerformance(result types.RotationPerformance) types.RotationPerformance {
+	result.OneDay = round(result.OneDay, 3)
+	result.OneWeek = round(result.OneWeek, 3)
+	result.OneMonth = round(result.OneMonth, 3)
+	result.ThreeMonths = round(result.ThreeMonths, 3)
+	result.SixMonths = round(result.SixMonths, 3)
+	result.OneYear = round(result.OneYear, 3)
+	result.PriorTwoMonthPace = round(result.PriorTwoMonthPace, 3)
+	result.Acceleration = round(result.Acceleration, 3)
+	return result
+}
+
+func priorTwoMonthReturnPace(oneMonth, threeMonth float64) float64 {
+	denominator := 1 + oneMonth/100
+	if denominator <= 0 || 1+threeMonth/100 <= 0 {
+		return 0
+	}
+	return 100 * (math.Sqrt((1+threeMonth/100)/denominator) - 1)
+}
+
+func completePerformance(row types.ETFFundFlowPerformance) bool {
+	return row.Change != nil && row.OneWeek != nil && row.OneMonth != nil && row.ThreeMonths != nil && row.SixMonths != nil && row.OneYear != nil
+}
+
+func completeIndustryPerformance(row types.USAIndustryPerformance) bool {
+	return row.Change != nil && row.OneWeek != nil && row.OneMonth != nil && row.ThreeMonths != nil && row.SixMonths != nil && row.OneYear != nil
+}
+
+func completeStockPerformance(row types.USAIndustryStockPerformance) bool {
+	return row.Change != nil && row.OneWeek != nil && row.OneMonth != nil && row.ThreeMonths != nil && row.SixMonths != nil && row.OneYear != nil && row.VolatilityOneMonth != nil
+}
+
+func percentileRank(values []float64, value float64) float64 {
+	if len(values) == 0 {
+		return 0
+	}
+	count := 0
+	for _, candidate := range values {
+		if candidate <= value {
+			count++
+		}
+	}
+	return float64(count) / float64(len(values))
+}
+
+func flowMetric(rows []types.SectorFundFlowSummary, metric func(types.SectorFundFlowSummary) float64) []float64 {
+	result := make([]float64, 0, len(rows))
+	for _, row := range rows {
+		result = append(result, metric(row))
+	}
+	return result
+}
+
+func etfMetric(rows []joinedSectorETF, metric func(joinedSectorETF) float64) []float64 {
+	result := make([]float64, 0, len(rows))
+	for _, row := range rows {
+		if row.class == "subsector" {
+			result = append(result, metric(row))
+		}
+	}
+	return result
+}
+
+func safePercent(numerator, denominator float64) float64 {
+	if denominator == 0 {
+		return 0
+	}
+	return 100 * numerator / denominator
+}
+
+func value(v *float64) float64 {
+	if v == nil {
+		return 0
+	}
+	return *v
+}
+
+func round(value float64, places int) float64 {
+	factor := math.Pow10(places)
+	return math.Round(value*factor) / factor
+}
+
+func rotationFingerprint(brief *types.MarketRotationBrief) (string, error) {
+	type rankedShape struct {
+		Key         string                    `json:"key"`
+		Setup       string                    `json:"setup"`
+		Score       float64                   `json:"score"`
+		Performance types.RotationPerformance `json:"performance"`
+	}
+	normalizedFlows := append([]types.SectorFundFlowSummary(nil), brief.SectorFundFlows...)
+	for i := range normalizedFlows {
+		normalizedFlows[i].HistoryTransition = ""
+	}
+	payload := struct {
+		Version    string                        `json:"version"`
+		Flows      []types.SectorFundFlowSummary `json:"flows"`
+		Broad      []rankedShape                 `json:"broad"`
+		Subsectors []rankedShape                 `json:"subsectors"`
+		Industries []rankedShape                 `json:"industries"`
+		Stocks     []rankedShape                 `json:"stocks"`
+	}{Version: brief.MethodologyVersion, Flows: normalizedFlows}
+	for _, row := range brief.BroadSectorRotations {
+		payload.Broad = append(payload.Broad, rankedShape{row.Sector, row.Setup, row.Score, row.Performance})
+	}
+	for _, row := range brief.SubsectorRotations {
+		payload.Subsectors = append(payload.Subsectors, rankedShape{row.Ticker, row.Setup, row.Score, row.Performance})
+	}
+	for _, row := range brief.PerformanceLedIndustries {
+		payload.Industries = append(payload.Industries, rankedShape{row.ID, row.Setup, row.Score, row.Performance})
+	}
+	for _, row := range brief.StockCandidates {
+		payload.Stocks = append(payload.Stocks, rankedShape{row.Ticker, row.Setup, row.Score, row.Performance})
+	}
+	data, err := json.Marshal(payload)
+	if err != nil {
+		return "", fmt.Errorf("marshal rotation fingerprint: %w", err)
+	}
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:]), nil
+}
+
+func detectLostConfirmations(previous *marketRotationSnapshot, current *types.MarketRotationBrief) []types.RotationLostConfirmation {
+	if previous == nil {
+		return nil
+	}
+	currentKeys := make(map[string]bool)
+	for _, row := range current.BroadSectorRotations {
+		currentKeys["broad:"+row.Sector] = true
+	}
+	for _, row := range current.SubsectorRotations {
+		currentKeys["subsector:"+row.Ticker] = true
+	}
+	for _, row := range current.StockCandidates {
+		currentKeys["stock:"+row.Ticker] = true
+	}
+	result := make([]types.RotationLostConfirmation, 0)
+	for _, row := range previous.Brief.BroadSectorRotations {
+		if !currentKeys["broad:"+row.Sector] {
+			result = append(result, types.RotationLostConfirmation{Kind: "broad_sector", Key: row.Sector, PreviousScore: row.Score})
+		}
+	}
+	for _, row := range previous.Brief.SubsectorRotations {
+		if !currentKeys["subsector:"+row.Ticker] {
+			result = append(result, types.RotationLostConfirmation{Kind: "subsector", Key: row.Ticker, PreviousScore: row.Score})
+		}
+	}
+	for _, row := range previous.Brief.StockCandidates {
+		if !currentKeys["stock:"+row.Ticker] {
+			result = append(result, types.RotationLostConfirmation{Kind: "stock", Key: row.Ticker, PreviousScore: row.Score})
+		}
+	}
+	return result
+}
+
+func loadLatestRotationSnapshot(db databaseStore) (*marketRotationSnapshot, error) {
+	if db == nil {
+		return nil, nil
+	}
+	keys, err := db.GetAllKeysWithPrefix(string(types.MarketRotationKeyPrefix))
+	if err != nil || len(keys) == 0 {
+		return nil, err
+	}
+	sort.Strings(keys)
+	var snapshot marketRotationSnapshot
+	if err := db.Get(keys[len(keys)-1], &snapshot); err != nil {
+		return nil, err
+	}
+	return &snapshot, nil
+}
+
+func persistRotationSnapshot(db databaseStore, brief types.MarketRotationBrief, fingerprint string) error {
+	key := fmt.Sprintf("%s:%s", types.MarketRotationKeyPrefix, brief.USSessionDate)
+	if err := db.Put(key, marketRotationSnapshot{Fingerprint: fingerprint, Brief: brief}); err != nil {
+		return fmt.Errorf("persist market rotation snapshot: %w", err)
+	}
+	keys, err := db.GetAllKeysWithPrefix(string(types.MarketRotationKeyPrefix))
+	if err != nil {
+		return fmt.Errorf("list market rotation history: %w", err)
+	}
+	sort.Strings(keys)
+	for len(keys) > maxRotationHistory {
+		if err := db.Delete(keys[0]); err != nil {
+			return fmt.Errorf("prune market rotation history: %w", err)
+		}
+		keys = keys[1:]
+	}
+	return nil
+}
+
+func sectorTransition(previous *marketRotationSnapshot, sector string, score float64) string {
+	if previous == nil {
+		return "baseline"
+	}
+	for _, row := range previous.Brief.BroadSectorRotations {
+		if row.Sector == sector {
+			return scoreTransition(row.Score, score)
+		}
+	}
+	return "new"
+}
+
+func subsectorTransition(previous *marketRotationSnapshot, ticker string, score float64) string {
+	if previous == nil {
+		return "baseline"
+	}
+	for _, row := range previous.Brief.SubsectorRotations {
+		if row.Ticker == ticker {
+			return scoreTransition(row.Score, score)
+		}
+	}
+	return "new"
+}
+
+func industryTransition(previous *marketRotationSnapshot, industry string, score float64) string {
+	if previous == nil {
+		return "baseline"
+	}
+	for _, row := range previous.Brief.PerformanceLedIndustries {
+		if row.Industry == industry {
+			return scoreTransition(row.Score, score)
+		}
+	}
+	return "new"
+}
+
+func stockTransition(previous *marketRotationSnapshot, ticker string, score float64) string {
+	if previous == nil {
+		return "baseline"
+	}
+	for _, row := range previous.Brief.StockCandidates {
+		if row.Ticker == ticker {
+			return scoreTransition(row.Score, score)
+		}
+	}
+	return "new"
+}
+
+func historyScore(previous *marketRotationSnapshot, ticker string) float64 {
+	if previous == nil {
+		return 0.5
+	}
+	for _, row := range previous.Brief.StockCandidates {
+		if row.Ticker == ticker {
+			return 0.7
+		}
+	}
+	return 1.0
+}
+
+func scoreTransition(previous, current float64) string {
+	switch {
+	case current >= previous+5:
+		return "strengthening"
+	case current <= previous-5:
+		return "weakening"
+	default:
+		return "unchanged"
+	}
+}

--- a/pkg/mdata/market_rotation_live_test.go
+++ b/pkg/mdata/market_rotation_live_test.go
@@ -1,0 +1,28 @@
+//go:build integration
+
+package mdata
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"portfolio-manager/pkg/mdata/sources"
+	"portfolio-manager/pkg/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLiveMarketRotationDryRun(t *testing.T) {
+	manager := &Manager{screenerSources: map[string]types.ScreenerSource{sources.TradingView: sources.NewTradingView()}}
+	brief, err := manager.ScreenDailyMarketRotation(MarketRotationOptions{PersistHistory: false, MaxStockCandidates: 5})
+	require.NoError(t, err)
+	require.NotEmpty(t, brief.SectorFundFlows)
+	require.LessOrEqual(t, len(brief.StockCandidates), 5)
+	require.False(t, brief.DataQuality.Persisted)
+
+	payload, err := json.Marshal(brief)
+	require.NoError(t, err)
+	require.Less(t, len(payload), 25_000, "MCP payload should remain compact")
+	t.Logf("live dry run at %s (%d bytes):\n%s", time.Now().Format(time.RFC3339), len(payload), payload)
+}

--- a/pkg/mdata/market_rotation_test.go
+++ b/pkg/mdata/market_rotation_test.go
@@ -1,0 +1,286 @@
+package mdata
+
+import (
+	"encoding/json"
+	"errors"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"portfolio-manager/pkg/types"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestJoinAndFilterSectorETFsExcludesUnsafeProducts(t *testing.T) {
+	overviews := []types.ETFSectorOverview{
+		sectorOverview("xlf", "XLF", "State Street Financial Select Sector SPDR ETF", "AMEX", "Financials", 100),
+		sectorOverview("kbwb", "KBWB", "Invesco KBW Bank ETF", "NASDAQ", "Financials", 50),
+		sectorOverview("tsll", "TSLL", "Direxion Daily TSLA Bull 2X ETF", "NASDAQ", "Consumer discretionary", 20),
+		sectorOverview("foreign", "IITU", "iShares technology UCITS ETF", "LSE", "Information technology", 20),
+		sectorOverview("theme", "AIQ", "Global X Artificial Intelligence ETF", "NASDAQ", "Theme", 20),
+	}
+	performances := make([]types.ETFFundFlowPerformance, 0, len(overviews))
+	flows := make([]types.ETFFundFlows, 0, len(overviews))
+	for _, row := range overviews {
+		performances = append(performances, sectorPerformance(row.ID, row.Ticker, 1, 2, 4, 6, 8, 10))
+		flows = append(flows, sectorFlows(row.ID, row.Ticker, 5, 8))
+	}
+
+	joined, excluded := joinAndFilterSectorETFs(overviews, performances, flows)
+	require.Len(t, joined, 2)
+	require.Equal(t, "broad", joined[0].class)
+	require.Equal(t, "subsector", joined[1].class)
+	require.Equal(t, 1, excluded["leveraged_inverse_or_single_stock"])
+	require.Equal(t, 1, excluded["foreign_listing"])
+	require.Equal(t, 1, excluded["thematic"])
+}
+
+func TestAggregateSectorFlowsSeparatesBroadAndSubsector(t *testing.T) {
+	broad := joinedETFForTest("XLF", "broad", 100, 10, 15)
+	subsector := joinedETFForTest("KBWB", "subsector", 50, -2, -1)
+
+	rows := aggregateSectorFlows([]joinedSectorETF{broad, subsector})
+	require.Len(t, rows, 1)
+	row := rows[0]
+	require.Equal(t, "Financials", row.Sector)
+	require.InDelta(t, 8, row.OneMonthFlowUSD, 0.001)
+	require.InDelta(t, 5.333, row.OneMonthFlowPercentAUM, 0.001)
+	require.InDelta(t, 7.5, row.BroadFlowAccelerationPercentAUM, 0.001)
+	require.InDelta(t, -5, row.SubsectorFlowAccelerationPercentAUM, 0.001)
+	require.Equal(t, "broad_inflow_subsector_outflow", row.BroadSubsectorRelationship)
+	require.Equal(t, "XLF", row.LargestContributors[0].Ticker)
+	require.Equal(t, "KBWB", row.LargestDetractors[0].Ticker)
+}
+
+func TestIndustryCrosswalkCoversMixedTradingViewSectors(t *testing.T) {
+	tests := []struct {
+		stockSector string
+		industry    string
+		want        string
+		mapped      bool
+	}{
+		{"Finance", "Major Banks", "Financials", true},
+		{"Finance", "Real Estate Investment Trusts", "Real estate", true},
+		{"Electronic technology", "Semiconductors", "Information technology", true},
+		{"Electronic technology", "Aerospace & Defense", "Industrials", true},
+		{"Industrial services", "Oilfield Services/Equipment", "Energy", true},
+		{"Distribution services", "Medical Distributors", "Health care", true},
+		{"Consumer non-durables", "Apparel/Footwear", "Consumer discretionary", true},
+		{"Technology services", "Internet Software/Services", "Communication services", true},
+		{"Miscellaneous", "Miscellaneous", "", false},
+	}
+	for _, test := range tests {
+		t.Run(test.stockSector+"/"+test.industry, func(t *testing.T) {
+			got, ok := mapIndustryToETFSector(test.stockSector, test.industry)
+			require.Equal(t, test.mapped, ok)
+			require.Equal(t, test.want, got)
+		})
+	}
+}
+
+func TestSetupAndOneDaySpikeClassification(t *testing.T) {
+	recovery := types.RotationPerformance{OneDay: 1, OneWeek: 2, OneMonth: 4, SixMonths: -1, OneYear: 5}
+	require.Equal(t, "recovery", setupType(recovery, 0.2, 0.9, 0.3))
+	ignition := types.RotationPerformance{OneDay: 1, OneWeek: 3, OneMonth: 5, SixMonths: 2, OneYear: 4}
+	require.Equal(t, "ignition", setupType(ignition, 0.5, 0.8, 0.5))
+	require.True(t, oneDaySpike(types.RotationPerformance{OneDay: 4, OneWeek: 5}, 0.95))
+	require.False(t, oneDaySpike(types.RotationPerformance{OneDay: 1, OneWeek: 5}, 0.95))
+}
+
+func TestHistoryTransitionsAndLostConfirmations(t *testing.T) {
+	previous := &marketRotationSnapshot{Brief: types.MarketRotationBrief{
+		SectorFundFlows:      []types.SectorFundFlowSummary{{Sector: "Technology", FlowAccelerationPercentAUM: -0.5}},
+		BroadSectorRotations: []types.SectorRotationSignal{{Sector: "Technology", Score: 80}},
+		StockCandidates:      []types.StockRotationCandidate{{Ticker: "OLD", Score: 75}},
+	}}
+	rows := []types.SectorFundFlowSummary{{Sector: "Technology", FlowAccelerationPercentAUM: 0.4}}
+	applySectorFlowTransitions(rows, previous)
+	require.Equal(t, "newly_accelerating", rows[0].HistoryTransition)
+
+	lost := detectLostConfirmations(previous, &types.MarketRotationBrief{})
+	require.Len(t, lost, 2)
+	require.Equal(t, "broad_sector", lost[0].Kind)
+	require.Equal(t, "stock", lost[1].Kind)
+}
+
+func TestScreenDailyMarketRotationPersistenceAndStaleDetection(t *testing.T) {
+	screener := rotationTestScreener{
+		overviews:    []types.ETFSectorOverview{sectorOverview("xlf", "XLF", "State Street Financial Select Sector SPDR ETF", "AMEX", "Financials", 100)},
+		performances: []types.ETFFundFlowPerformance{sectorPerformance("xlf", "XLF", 1, 2, 4, 8, 10, 12)},
+		flows:        []types.ETFFundFlows{sectorFlows("xlf", "XLF", 10, 12)},
+	}
+	db := newMemoryRotationDB()
+	now := time.Date(2026, 6, 24, 10, 30, 0, 0, time.UTC)
+
+	first, err := screenDailyMarketRotation(&screener, db, MarketRotationOptions{PersistHistory: true, MaxStockCandidates: 5}, now)
+	require.NoError(t, err)
+	require.True(t, first.DataQuality.Persisted)
+	require.False(t, first.DataQuality.Stale)
+	require.Len(t, db.values, 1)
+
+	second, err := screenDailyMarketRotation(&screener, db, MarketRotationOptions{PersistHistory: true, MaxStockCandidates: 5}, now.Add(time.Hour))
+	require.NoError(t, err)
+	require.True(t, second.DataQuality.Stale)
+	require.False(t, second.DataQuality.Persisted)
+	require.Len(t, db.values, 1)
+
+	dryRun, err := screenDailyMarketRotation(&screener, nil, MarketRotationOptions{PersistHistory: false, MaxStockCandidates: 5}, now)
+	require.NoError(t, err)
+	require.False(t, dryRun.DataQuality.Persisted)
+}
+
+func TestScreenDailyMarketRotationReturnsOnlyQualifiedStocks(t *testing.T) {
+	screener := rotationTestScreener{
+		overviews:    []types.ETFSectorOverview{sectorOverview("xlf", "XLF", "State Street Financial Select Sector SPDR ETF", "AMEX", "Financials", 100)},
+		performances: []types.ETFFundFlowPerformance{sectorPerformance("xlf", "XLF", 0.2, 2, 4, 8, 10, 12)},
+		flows:        []types.ETFFundFlows{sectorFlows("xlf", "XLF", 10, 12)},
+		industries: []types.USAIndustryOverview{{
+			ID: "banks", Industry: "Major Banks", Sector: "Finance",
+		}},
+		industryPerf:     []types.USAIndustryPerformance{industryPerformance("banks", "Major Banks", 0.2, 2, 5, 4, -3, -2)},
+		stockOverviews:   map[string][]types.USAIndustryStockOverview{"Major Banks": makeTestStockOverviews()},
+		stockPerformance: map[string][]types.USAIndustryStockPerformance{"Major Banks": makeTestStockPerformance()},
+	}
+
+	brief, err := screenDailyMarketRotation(&screener, nil, MarketRotationOptions{PersistHistory: false, MaxStockCandidates: 5}, time.Date(2026, 6, 24, 10, 30, 0, 0, time.UTC))
+	require.NoError(t, err)
+	require.NotEmpty(t, brief.StockCandidates)
+	require.LessOrEqual(t, len(brief.StockCandidates), 5)
+	for _, stock := range brief.StockCandidates {
+		require.GreaterOrEqual(t, stock.MarketCapUSD, 2_000_000_000.0)
+		require.GreaterOrEqual(t, stock.DailyTurnoverUSD, 20_000_000.0)
+		require.NotEqual(t, "LOWCAP", stock.Ticker)
+	}
+	require.Greater(t, brief.RejectedStockCounts["market_cap_below_2b"], 0)
+}
+
+type rotationTestScreener struct {
+	MarketDataScreener
+	overviews        []types.ETFSectorOverview
+	performances     []types.ETFFundFlowPerformance
+	flows            []types.ETFFundFlows
+	industries       []types.USAIndustryOverview
+	industryPerf     []types.USAIndustryPerformance
+	stockOverviews   map[string][]types.USAIndustryStockOverview
+	stockPerformance map[string][]types.USAIndustryStockPerformance
+}
+
+func (s *rotationTestScreener) FetchETFSectorOverview() ([]types.ETFSectorOverview, error) {
+	return s.overviews, nil
+}
+
+func (s *rotationTestScreener) FetchETFSectorPerformance() ([]types.ETFFundFlowPerformance, error) {
+	return s.performances, nil
+}
+
+func (s *rotationTestScreener) FetchETFSectorFundFlows() ([]types.ETFFundFlows, error) {
+	return s.flows, nil
+}
+
+func (s *rotationTestScreener) FetchUSAIndustryOverview() ([]types.USAIndustryOverview, error) {
+	return s.industries, nil
+}
+
+func (s *rotationTestScreener) FetchUSAIndustryPerformance() ([]types.USAIndustryPerformance, error) {
+	return s.industryPerf, nil
+}
+
+func (s *rotationTestScreener) FetchUSAIndustryStocksOverview(industry string) ([]types.USAIndustryStockOverview, error) {
+	return s.stockOverviews[industry], nil
+}
+
+func (s *rotationTestScreener) FetchUSAIndustryStocksPerformance(industry string) ([]types.USAIndustryStockPerformance, error) {
+	return s.stockPerformance[industry], nil
+}
+
+type memoryRotationDB struct {
+	values map[string][]byte
+}
+
+func newMemoryRotationDB() *memoryRotationDB {
+	return &memoryRotationDB{values: make(map[string][]byte)}
+}
+
+func (db *memoryRotationDB) Get(key string, value interface{}) error {
+	data, ok := db.values[key]
+	if !ok {
+		return errors.New("not found")
+	}
+	return json.Unmarshal(data, value)
+}
+
+func (db *memoryRotationDB) Put(key string, value interface{}) error {
+	data, err := json.Marshal(value)
+	if err != nil {
+		return err
+	}
+	db.values[key] = data
+	return nil
+}
+
+func (db *memoryRotationDB) Delete(key string) error {
+	delete(db.values, key)
+	return nil
+}
+
+func (db *memoryRotationDB) GetAllKeysWithPrefix(prefix string) ([]string, error) {
+	keys := make([]string, 0)
+	for key := range db.values {
+		if strings.HasPrefix(key, prefix) {
+			keys = append(keys, key)
+		}
+	}
+	sort.Strings(keys)
+	return keys, nil
+}
+
+func sectorOverview(id, ticker, fund, exchange, focus string, aum float64) types.ETFSectorOverview {
+	price := 10.0
+	return types.ETFSectorOverview{ID: id, Ticker: ticker, Fund: fund, Exchange: exchange, AssetsUnderManagement: &aum, AUMCurrency: "USD", Price: &price, Currency: "USD", AssetClass: "Equity", Focus: focus}
+}
+
+func sectorPerformance(id, ticker string, day, week, month, three, six, year float64) types.ETFFundFlowPerformance {
+	return types.ETFFundFlowPerformance{ID: id, Ticker: ticker, Change: &day, OneWeek: &week, OneMonth: &month, ThreeMonths: &three, SixMonths: &six, OneYear: &year}
+}
+
+func sectorFlows(id, ticker string, month, three float64) types.ETFFundFlows {
+	return types.ETFFundFlows{ID: id, Ticker: ticker, Currency: "USD", OneMonth: &month, ThreeMonths: &three}
+}
+
+func joinedETFForTest(ticker, class string, aum, month, three float64) joinedSectorETF {
+	overview := sectorOverview(strings.ToLower(ticker), ticker, ticker+" fund", "AMEX", "Financials", aum)
+	flows := sectorFlows(strings.ToLower(ticker), ticker, month, three)
+	return joinedSectorETF{overview: overview, flows: flows, class: class, sector: "Financials", perf: types.RotationPerformance{OneWeek: 2, OneMonth: 4, ThreeMonths: 6}}
+}
+
+func industryPerformance(id, industry string, day, week, month, three, six, year float64) types.USAIndustryPerformance {
+	return types.USAIndustryPerformance{ID: id, Industry: industry, Change: &day, OneWeek: &week, OneMonth: &month, ThreeMonths: &three, SixMonths: &six, OneYear: &year}
+}
+
+func makeTestStockOverviews() []types.USAIndustryStockOverview {
+	result := make([]types.USAIndustryStockOverview, 0, 6)
+	for i, ticker := range []string{"BANKA", "BANKB", "BANKC", "BANKD", "BANKE", "LOWCAP"} {
+		marketCap := 10_000_000_000.0 + float64(i)*1_000_000_000
+		if ticker == "LOWCAP" {
+			marketCap = 500_000_000
+		}
+		price, volume := 50.0, 1_000_000.0
+		result = append(result, types.USAIndustryStockOverview{ID: strings.ToLower(ticker), Ticker: ticker, Company: ticker + " Inc", Currency: "USD", MarketCap: &marketCap, Price: &price, Volume: &volume})
+	}
+	return result
+}
+
+func makeTestStockPerformance() []types.USAIndustryStockPerformance {
+	result := make([]types.USAIndustryStockPerformance, 0, 6)
+	for i, ticker := range []string{"BANKA", "BANKB", "BANKC", "BANKD", "BANKE", "LOWCAP"} {
+		day := 0.1
+		week := 2.0 + float64(i)/10
+		month := 5.0 + float64(i)
+		three, six, year := 4.0, -3.0, -2.0
+		volatility := 1.0 + float64(i)/10
+		result = append(result, types.USAIndustryStockPerformance{ID: strings.ToLower(ticker), Ticker: ticker, Change: &day, OneWeek: &week, OneMonth: &month, ThreeMonths: &three, SixMonths: &six, OneYear: &year, VolatilityOneMonth: &volatility})
+	}
+	return result
+}

--- a/pkg/mdata/mcp.go
+++ b/pkg/mdata/mcp.go
@@ -18,6 +18,7 @@ const (
 	toolFetchSectorETFOverview              = "fetch_sector_etf_overview"
 	toolFetchSectorETFPerformance           = "fetch_sector_etf_performance"
 	toolFetchSectorETFFundFlows             = "fetch_sector_etf_fund_flows"
+	toolScreenDailyMarketRotation           = "screen_daily_market_rotation"
 )
 
 // RegisterMCPTools registers market data MCP tools.
@@ -87,6 +88,14 @@ func RegisterScreenerMCPTools(mcpServer *server.MCPServer, screener MarketDataSc
 		mcp.NewTool(toolFetchSectorETFOverview, mcp.WithDescription("Fetch overview metrics for the top 100 global sector ETFs. This returns ETFs, not stock-market industries or their underlying companies.")),
 		createHandleFetchETFSectorOverview(screener.FetchETFSectorOverview),
 	)
+	if rotationScreener, ok := screener.(MarketRotationScreener); ok {
+		rotationTool := mcp.NewTool(toolScreenDailyMarketRotation,
+			mcp.WithDescription("Build a deterministic daily US market-rotation brief from TradingView sector ETF fund flows, sector/industry performance, and stock performance. All joins, calculations, rankings, exclusions, and history transitions are precomputed; narrate the returned order without recalculating or inventing stock-level fund flows."),
+			mcp.WithBoolean("persist_history", mcp.Description("Persist this US session for transition detection. Defaults to true; set false for validation and dry runs.")),
+			mcp.WithNumber("max_stock_candidates", mcp.Description("Maximum stock candidates to return, from 1 to 5. Defaults to 5.")),
+		)
+		mcpServer.AddTool(rotationTool, createHandleScreenDailyMarketRotation(rotationScreener))
+	}
 }
 
 func createHandleFetchUSAIndustryOverview(manager MarketDataScreener) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
@@ -174,6 +183,30 @@ func createHandleFetchETFSectorOverview(fetch func() ([]types.ETFSectorOverview,
 			return mcp.NewToolResultError(fmt.Sprintf("Failed to fetch sector ETF overview: %v", err)), nil
 		}
 		return industryToolResult(newETFSectorOverviewResponse(etfs))
+	}
+}
+
+func createHandleScreenDailyMarketRotation(screener MarketRotationScreener) func(context.Context, mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+	return func(_ context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
+		maxCandidates, err := request.RequireInt("max_stock_candidates")
+		if err != nil {
+			maxCandidates = defaultMaxStockCandidates
+		}
+		if maxCandidates < 1 || maxCandidates > defaultMaxStockCandidates {
+			return mcp.NewToolResultError("max_stock_candidates must be between 1 and 5"), nil
+		}
+		brief, err := screener.ScreenDailyMarketRotation(MarketRotationOptions{
+			PersistHistory:     request.GetBool("persist_history", true),
+			MaxStockCandidates: maxCandidates,
+		})
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to screen daily market rotation: %v", err)), nil
+		}
+		jsonData, err := json.Marshal(brief)
+		if err != nil {
+			return mcp.NewToolResultError(fmt.Sprintf("Failed to marshal market rotation brief: %v", err)), nil
+		}
+		return mcp.NewToolResultText(string(jsonData)), nil
 	}
 }
 

--- a/pkg/mdata/mcp_test.go
+++ b/pkg/mdata/mcp_test.go
@@ -26,6 +26,7 @@ func TestScreenerMCPToolNamesDisambiguateStockIndustriesAndSectorETFs(t *testing
 		toolFetchSectorETFOverview,
 		toolFetchSectorETFPerformance,
 		toolFetchSectorETFFundFlows,
+		toolScreenDailyMarketRotation,
 	} {
 		require.Contains(t, tools, name)
 	}
@@ -38,6 +39,29 @@ func TestScreenerMCPToolNamesDisambiguateStockIndustriesAndSectorETFs(t *testing
 	}
 	require.Contains(t, tools[toolFetchStockIndustryPerformance].Tool.Description, "no fund-flow fields")
 	require.Contains(t, tools[toolFetchSectorETFFundFlows].Tool.Description, "stock industries do not provide fund flows")
+}
+
+func TestScreenDailyMarketRotationMCPHandler(t *testing.T) {
+	runner := &rotationMCPTestRunner{brief: &types.MarketRotationBrief{MethodologyVersion: types.MarketRotationMethodologyVersion}}
+	request := mcp.CallToolRequest{Params: mcp.CallToolParams{Arguments: map[string]any{
+		"persist_history": false, "max_stock_candidates": float64(3),
+	}}}
+
+	result, err := createHandleScreenDailyMarketRotation(runner)(context.Background(), request)
+	require.NoError(t, err)
+	require.False(t, result.IsError)
+	require.False(t, runner.options.PersistHistory)
+	require.Equal(t, 3, runner.options.MaxStockCandidates)
+}
+
+type rotationMCPTestRunner struct {
+	brief   *types.MarketRotationBrief
+	options MarketRotationOptions
+}
+
+func (r *rotationMCPTestRunner) ScreenDailyMarketRotation(options MarketRotationOptions) (*types.MarketRotationBrief, error) {
+	r.options = options
+	return r.brief, nil
 }
 
 func TestFetchUSAIndustryOverviewMCPHandler(t *testing.T) {

--- a/pkg/mdata/mdata.go
+++ b/pkg/mdata/mdata.go
@@ -46,8 +46,20 @@ type MarketDataScreener interface {
 	FetchETFSectorFundFlows() ([]types.ETFFundFlows, error)
 }
 
+// MarketRotationScreener provides deterministic, compact daily rotation analysis.
+type MarketRotationScreener interface {
+	ScreenDailyMarketRotation(options MarketRotationOptions) (*types.MarketRotationBrief, error)
+}
+
+// MarketRotationOptions controls persistence and response size.
+type MarketRotationOptions struct {
+	PersistHistory     bool
+	MaxStockCandidates int
+}
+
 // Manager handles multiple data sources with fallback capability
 type Manager struct {
+	db              dal.Database
 	sources         map[string]types.DataSource
 	futuresSources  map[string]*sources.BarchartsSource
 	screenerSources map[string]types.ScreenerSource
@@ -183,6 +195,7 @@ func newETFSectorOverviewResponse(etfs []types.ETFSectorOverview) types.ETFSecto
 // NewManager creates a new data manager with initialized data sources
 func NewManager(db dal.Database, rdata rdata.ReferenceManager) (*Manager, error) {
 	m := &Manager{
+		db:              db,
 		sources:         make(map[string]types.DataSource),
 		futuresSources:  make(map[string]*sources.BarchartsSource),
 		screenerSources: make(map[string]types.ScreenerSource),

--- a/pkg/types/db_keys.go
+++ b/pkg/types/db_keys.go
@@ -17,6 +17,7 @@ const (
 	InterestRatesKeyPrefix     dbKey = "INTEREST_RATES" // Key prefix for interest rates data
 	HistoricalMetricsKeyPrefix dbKey = "METRICS"        // Key prefix for historical metrics
 	AnalyticsSummaryKeyPrefix  dbKey = "ANALYTICS_SUMMARY"
+	MarketRotationKeyPrefix    dbKey = "MARKET_ROTATION"
 	MigrationKeyPrefix         dbKey = "MIGRATION" // Key prefix for migration tracking
 
 	ScheduledJobKeyPrefix           dbKey = "SCHEDULED_JOB"            // Key prefix for registered scheduled jobs

--- a/pkg/types/market_rotation.go
+++ b/pkg/types/market_rotation.go
@@ -1,0 +1,146 @@
+package types
+
+// MarketRotationMethodologyVersion changes whenever scoring or classification semantics change.
+const MarketRotationMethodologyVersion = "1.0.0"
+
+// ETFContribution explains which ETF materially affected a sector's aggregate flow.
+type ETFContribution struct {
+	Ticker         string  `json:"ticker"`
+	Fund           string  `json:"fund"`
+	Classification string  `json:"classification"`
+	OneMonthFlow   float64 `json:"one_month_flow_usd"`
+}
+
+// RotationPerformance contains the return shape used by the deterministic scorer.
+type RotationPerformance struct {
+	OneDay            float64 `json:"one_day_percent"`
+	OneWeek           float64 `json:"one_week_percent"`
+	OneMonth          float64 `json:"one_month_percent"`
+	ThreeMonths       float64 `json:"three_months_percent"`
+	SixMonths         float64 `json:"six_months_percent"`
+	OneYear           float64 `json:"one_year_percent"`
+	PriorTwoMonthPace float64 `json:"prior_two_month_monthly_pace_percent"`
+	Acceleration      float64 `json:"one_month_acceleration_percent"`
+}
+
+// SectorFundFlowSummary is the compact, precomputed input for the LLM's 1M flow narrative.
+type SectorFundFlowSummary struct {
+	Sector                              string              `json:"sector"`
+	ETFCount                            int                 `json:"etf_count"`
+	BroadETFCount                       int                 `json:"broad_etf_count"`
+	SubsectorETFCount                   int                 `json:"subsector_etf_count"`
+	PositiveFlowETFCount                int                 `json:"positive_flow_etf_count"`
+	PositiveFlowBreadthPercent          float64             `json:"positive_flow_breadth_percent"`
+	CombinedAUMUSD                      float64             `json:"combined_aum_usd"`
+	OneMonthFlowUSD                     float64             `json:"one_month_flow_usd"`
+	ThreeMonthFlowUSD                   float64             `json:"three_month_flow_usd"`
+	OneMonthFlowPercentAUM              float64             `json:"one_month_flow_percent_aum"`
+	PriorTwoMonthMonthlyFlowUSD         float64             `json:"prior_two_month_monthly_flow_usd"`
+	PriorTwoMonthMonthlyPercentAUM      float64             `json:"prior_two_month_monthly_percent_aum"`
+	FlowAccelerationPercentAUM          float64             `json:"flow_acceleration_percent_aum"`
+	BroadOneMonthFlowUSD                float64             `json:"broad_one_month_flow_usd"`
+	SubsectorOneMonthFlowUSD            float64             `json:"subsector_one_month_flow_usd"`
+	BroadFlowAccelerationPercentAUM     float64             `json:"broad_flow_acceleration_percent_aum"`
+	SubsectorFlowAccelerationPercentAUM float64             `json:"subsector_flow_acceleration_percent_aum"`
+	BroadSubsectorRelationship          string              `json:"broad_subsector_relationship"`
+	FlowTrend                           string              `json:"flow_trend"`
+	HistoryTransition                   string              `json:"history_transition"`
+	BroadPerformance                    RotationPerformance `json:"broad_performance"`
+	PerformanceFlowAlignment            string              `json:"performance_flow_alignment"`
+	LargestContributors                 []ETFContribution   `json:"largest_contributors"`
+	LargestDetractors                   []ETFContribution   `json:"largest_detractors"`
+}
+
+// SectorRotationSignal describes a broad-sector setup.
+type SectorRotationSignal struct {
+	Sector      string              `json:"sector"`
+	Setup       string              `json:"setup"`
+	Score       float64             `json:"score"`
+	Transition  string              `json:"transition"`
+	FlowTrend   string              `json:"flow_trend"`
+	Performance RotationPerformance `json:"performance"`
+}
+
+// SubsectorRotationSignal describes an independently confirmed industry/subsector ETF move.
+type SubsectorRotationSignal struct {
+	Ticker           string              `json:"ticker"`
+	Fund             string              `json:"fund"`
+	Sector           string              `json:"sector"`
+	MappedIndustries []string            `json:"mapped_industries,omitempty"`
+	Setup            string              `json:"setup"`
+	Score            float64             `json:"score"`
+	Transition       string              `json:"transition"`
+	OneMonthFlowUSD  float64             `json:"one_month_flow_usd"`
+	FlowPercentAUM   float64             `json:"one_month_flow_percent_aum"`
+	FlowAcceleration float64             `json:"flow_acceleration_percent_aum"`
+	Performance      RotationPerformance `json:"performance"`
+}
+
+// IndustryRotationSignal is an industry selected for stock drill-down.
+type IndustryRotationSignal struct {
+	ID          string              `json:"id"`
+	Industry    string              `json:"industry"`
+	StockSector string              `json:"stock_sector"`
+	ETFSector   string              `json:"etf_sector"`
+	Lane        string              `json:"lane"`
+	Setup       string              `json:"setup"`
+	Score       float64             `json:"score"`
+	Transition  string              `json:"transition"`
+	Performance RotationPerformance `json:"performance"`
+}
+
+// StockRotationCandidate is a deterministic candidate, not an LLM-generated recommendation.
+type StockRotationCandidate struct {
+	Ticker            string              `json:"ticker"`
+	Company           string              `json:"company"`
+	Industry          string              `json:"industry"`
+	ETFSector         string              `json:"etf_sector"`
+	Lane              string              `json:"lane"`
+	Setup             string              `json:"setup"`
+	Score             float64             `json:"score"`
+	Transition        string              `json:"transition"`
+	MarketCapUSD      float64             `json:"market_cap_usd"`
+	DailyTurnoverUSD  float64             `json:"daily_turnover_usd"`
+	MonthlyVolatility float64             `json:"monthly_volatility_percent"`
+	EPSGrowthYoY      *float64            `json:"eps_growth_yoy_percent,omitempty"`
+	AnalystRating     string              `json:"analyst_rating,omitempty"`
+	Performance       RotationPerformance `json:"performance"`
+	Invalidation      string              `json:"invalidation"`
+}
+
+// RotationLostConfirmation identifies a signal present in the prior session but absent now.
+type RotationLostConfirmation struct {
+	Kind          string  `json:"kind"`
+	Key           string  `json:"key"`
+	PreviousScore float64 `json:"previous_score"`
+}
+
+// MarketRotationDataQuality makes exclusions and partial coverage visible to the LLM and user.
+type MarketRotationDataQuality struct {
+	Source                string         `json:"source"`
+	SourceURL             string         `json:"source_url"`
+	InputETFCount         int            `json:"input_etf_count"`
+	EligibleETFCount      int            `json:"eligible_etf_count"`
+	ExcludedETFCount      int            `json:"excluded_etf_count"`
+	ExclusionsByReason    map[string]int `json:"exclusions_by_reason"`
+	UnmappedIndustryCount int            `json:"unmapped_industry_count"`
+	Stale                 bool           `json:"stale"`
+	Persisted             bool           `json:"persisted"`
+	Warnings              []string       `json:"warnings,omitempty"`
+}
+
+// MarketRotationBrief is intentionally compact so the LLM narrates rather than recomputes.
+type MarketRotationBrief struct {
+	AsOf                     string                     `json:"as_of"`
+	USSessionDate            string                     `json:"us_session_date"`
+	MethodologyVersion       string                     `json:"methodology_version"`
+	SectorFundFlows          []SectorFundFlowSummary    `json:"sector_fund_flows"`
+	BroadSectorRotations     []SectorRotationSignal     `json:"broad_sector_rotations"`
+	SubsectorRotations       []SubsectorRotationSignal  `json:"subsector_rotations"`
+	PerformanceLedIndustries []IndustryRotationSignal   `json:"performance_led_industries"`
+	StockCandidates          []StockRotationCandidate   `json:"stock_candidates"`
+	LostConfirmations        []RotationLostConfirmation `json:"lost_confirmations,omitempty"`
+	RejectedStockCounts      map[string]int             `json:"rejected_stock_counts"`
+	DataQuality              MarketRotationDataQuality  `json:"data_quality"`
+	BriefInstructions        []string                   `json:"brief_instructions"`
+}


### PR DESCRIPTION
This is an attempt to build a tradable strategy based off tradingview screening data, by incorporating daily market briefs on Openclaw.

The strategy attempts to identify new trends / reversals / current trends, with new trends being given a higher weightage.