### PR TITLE
feat(mdata): refine market rotation to give more weight to 3m funds flow

### DIFF
--- a/astro/src/content/docs/concepts/market-rotation.mdx
+++ b/astro/src/content/docs/concepts/market-rotation.mdx
@@ -5,7 +5,7 @@ description: Daily sector rotation and stock candidate screening strategy.
 
 # Market Rotation
 
-The daily market-rotation screen produces a post-US-close brief that explains one-month sector ETF product flows, identifies broad and subsector rotations, drills into matching USA stock industries, and returns zero to five liquid stock candidates.
+The daily market-rotation screen produces a post-US-close brief that explains one- to three-month sector ETF product flows, identifies broad and subsector rotations, drills into matching USA stock industries, and returns zero to five liquid stock candidates.
 
 Deterministic Go code owns data joins, calculations, exclusions, classifications, rankings, and history comparisons. The LLM owns concise interpretation only.
 
@@ -13,11 +13,11 @@ Deterministic Go code owns data joins, calculations, exclusions, classifications
 
 The source is TradingView's Sector ETFs page via table ID `etfs_funds.sector_etfs`. The rotation scorer restricts aggregates to US-listed, USD-denominated equity ETFs.
 
-The screen excludes foreign listings, non-USD funds, non-equity funds, thematic funds, leveraged or inverse products, and single-stock ETFs from sector aggregates.
+The screen excludes foreign listings, non-USD funds, non-equity funds, leveraged or inverse products, and single-stock ETFs from sector aggregates. Eligible thematic ETFs are mapped into economic sectors when recognizable, with an unmapped thematic fallback bucket.
 
 ## Flow Analysis
 
-For each sector, the screen precomputes combined AUM, one-month and three-month ETF product flows, normalized flow percentages, flow acceleration, breadth, broad versus subsector agreement, positive and negative contributors, and history state.
+For each sector, the screen precomputes combined AUM, one-month and three-month ETF product flows, normalized flow percentages, flow acceleration, breadth, broad versus subsector agreement, positive and negative contributors, and history state. The sector flow list is ordered by an equal-weight blend of one-month and three-month flow as a percentage of AUM.
 
 These are ETF product flows, not direct stock-level institutional flows.
 
@@ -33,7 +33,7 @@ Flow disagreement reduces confidence but does not automatically eliminate strong
 
 ## Stock Candidate Gates
 
-A qualified candidate must have USD pricing, market capitalization of at least `$2B`, price of at least `$5`, daily dollar turnover of at least `$20M`, positive short-term performance, positive return acceleration, and no disqualifying one-day spike.
+A qualified candidate must come from one of the top three sorted industry signals and have USD pricing, market capitalization of at least `$2B`, price of at least `$5`, daily dollar turnover of at least `$20M`, positive one-week, one-month, and three-month performance, positive return acceleration, and no disqualifying one-day spike.
 
 The screen must not fill a candidate quota when no setup qualifies.
 

--- a/docs/market-rotation-strategy.md
+++ b/docs/market-rotation-strategy.md
@@ -6,7 +6,7 @@ Tracking: [GitHub issue #183](https://github.com/rodionlim/portfolio-manager-go/
 
 ## Objective
 
-Produce a daily, post-US-close brief that explains one-month sector ETF product flows, identifies broad and subsector rotations, drills into matching USA stock industries, and returns zero to five liquid stock candidates. Deterministic Go code owns data joins, calculations, exclusions, classifications, rankings, and history comparisons. The LLM owns concise interpretation only.
+Produce a daily, post-US-close brief that explains one- to three-month sector ETF product flows, identifies broad and subsector rotations, drills into matching USA stock industries, and returns zero to five liquid stock candidates. Deterministic Go code owns data joins, calculations, exclusions, classifications, rankings, and history comparisons. The LLM owns concise interpretation only.
 
 The strategy targets weeks-to-months holding periods and prefers confirmed turns over anticipatory entries. It must never fill a candidate quota when no setup qualifies.
 
@@ -14,21 +14,24 @@ The strategy targets weeks-to-months holding periods and prefers confirmed turns
 
 The source is TradingView's [Sector ETFs page](https://www.tradingview.com/markets/etfs/funds-sector-etfs/) via table ID `etfs_funds.sector_etfs`, using its Overview, Performance, and Fund Flows tabs. The raw MCP tools retain the top-100 global screen. The rotation scorer restricts aggregates to US-listed, USD-denominated equity ETFs.
 
-Exclude foreign listings, non-USD funds, non-equity funds, thematic funds, leveraged/inverse products, and single-stock ETFs from sector aggregates. Return exclusion counts by reason.
+Exclude foreign listings, non-USD funds, non-equity funds, leveraged/inverse products, and single-stock ETFs from sector aggregates. Include eligible thematic ETFs by mapping recognizable themes to their economic sectors, with an unmapped Thematic fallback bucket. Return exclusion counts by reason.
 
 Classify remaining ETFs as:
 
 - Broad sector: the explicit pairs XLC/VOX, XLY/VCR, XLP/VDC, XLE/VDE, XLF/VFH, XLV/VHT, XLI/VIS, XLB/VAW, XLRE/VNQ, XLK/VGT, and XLU/VPU.
-- Subsector: other eligible, unleveraged sector or industry ETFs.
+- Subsector: other eligible, unleveraged sector, industry, or thematic ETFs.
 
-Subsector ETFs can create an independent secondary signal without claiming that the entire broad sector is confirmed.
+Subsector and thematic ETFs can create independent secondary signals without claiming that an entire broad sector is confirmed.
 
-## One-month sector flow analysis
+Map common themes deterministically from ticker and fund name into economic sectors and stock-industry hints: semiconductors and AI/robotics/software themes → Information Technology, defense/space → Industrials, metals/uranium/lithium → Materials, clean energy → Energy, biotech/genomics → Health Care, crypto/fintech → Financials, gaming/media → Communication Services, and retail/EV themes → Consumer Discretionary.
+
+## One- to three-month sector flow analysis
 
 For each sector, precompute:
 
 - Combined AUM and 1M/3M ETF product flows.
-- 1M flow as a percentage of combined AUM.
+- 1M and 3M flows as percentages of combined AUM.
+- Sector flow landscape ordering by an equal-weight blend of 1M and 3M flow/AUM percentages.
 - Prior two-month average monthly flow: `(Flow3M - Flow1M) / 2`.
 - Flow acceleration: current 1M normalized flow minus the prior two-month normalized monthly pace.
 - Breadth: positive-flow ETF count and percentage.
@@ -61,6 +64,8 @@ Reject actionable setups driven primarily by one top-decile trading day. Maintai
 2. Independent subsector rotation: medium-high confidence and explicitly labeled.
 3. Performance-led industry without flow confirmation: eligible but lower confidence.
 
+Score broad-sector and subsector ETF signals with 20% 1M flow/AUM percentile, 20% 3M flow/AUM percentile, 25% flow acceleration percentile, and 35% ETF performance acceleration percentile.
+
 Flow disagreement reduces confidence; it does not automatically eliminate strong industry performance.
 
 ## Industry mapping
@@ -81,14 +86,14 @@ Common explicit subsector hints include KBWB/KRE/KBE → banks, XBI/IBB → biot
 
 ## Stock eligibility and ranking
 
-Drill into at most five selected industries. A stock must have:
+Drill into at most three selected industries, using only the top three sorted industry signals. A stock must have:
 
 - USD pricing.
 - Market capitalization of at least $2 billion.
 - Price of at least $5.
 - Current daily dollar turnover of at least $20 million.
 - Monthly volatility outside the highest peer quintile.
-- Positive 1W and 1M performance with positive return acceleration.
+- Positive 1W, 1M, and 3M performance with positive return acceleration.
 - No disqualifying one-day spike.
 
 Do not use relative volume. Rank qualified stocks using individual performance/acceleration (60%), inherited sector-industry confidence (30%), and history state (10%). Fundamentals are tie-breakers and risk flags, not primary gates.
@@ -110,7 +115,7 @@ The full narration prompt, validation prompt, and suggested 6:30 a.m. Asia/Singa
 
 The brief order is:
 
-1. 1M sector fund-flow landscape.
+1. 1M/3M sector fund-flow landscape.
 2. Performance alignment and divergences.
 3. Broad-sector rotations.
 4. Independent subsector rotations.

--- a/docs/openclaw-market-rotation.md
+++ b/docs/openclaw-market-rotation.md
@@ -50,8 +50,8 @@ Write these sections in this order:
 
 ## Sector flow snapshot
 
-- In four compact bullets maximum, cover the top three sectors by 1M flow/AUM,
-  aligned-positive sectors, early flow-led sectors, and confirmed weakness.
+- In four compact bullets maximum, cover the top three sectors by the returned
+  1M/3M flow-AUM ordering, aligned-positive sectors, early flow-led sectors, and confirmed weakness.
 - Include percentages only when they make comparison easier.
 - Explain `flow_leads_performance` as "money moving in before price confirms"
   and `performance_leads_flow` as "price strength without broad fund-flow

--- a/pkg/mdata/market_rotation.go
+++ b/pkg/mdata/market_rotation.go
@@ -17,7 +17,7 @@ import (
 const (
 	defaultMaxStockCandidates = 5
 	maxRotationHistory        = 20
-	maxIndustryDrilldowns     = 5
+	maxIndustryDrilldowns     = 3
 	marketRotationSourceURL   = "https://www.tradingview.com/markets/etfs/funds-sector-etfs/"
 )
 
@@ -55,6 +55,76 @@ var subsectorIndustryHints = map[string][]string{
 	"XME":  {"Steel", "Aluminum", "Other Metals/Minerals"},
 }
 
+type thematicETFMapping struct {
+	sector     string
+	industries []string
+	keywords   []string
+	tickers    []string
+}
+
+var thematicETFMappings = []thematicETFMapping{
+	{
+		sector:     "Information technology",
+		industries: []string{"Semiconductors"},
+		keywords:   []string{"semiconductor", "semiconductors", "chip ", "chips"},
+		tickers:    []string{"SMH", "SOXX", "SOXQ"},
+	},
+	{
+		sector:     "Information technology",
+		industries: []string{"Semiconductors", "Packaged Software"},
+		keywords:   []string{"artificial intelligence", " ai ", "robotics", "automation", "quantum"},
+		tickers:    []string{"AIQ", "BOTZ", "ROBO", "ARKQ", "IRBO", "CHAT"},
+	},
+	{
+		sector:     "Information technology",
+		industries: []string{"Packaged Software"},
+		keywords:   []string{"software", "cloud", "cybersecurity", "cyber security"},
+		tickers:    []string{"IGV", "CIBR", "HACK", "SKYY", "WCLD"},
+	},
+	{
+		sector:     "Industrials",
+		industries: []string{"Aerospace & Defense"},
+		keywords:   []string{"aerospace", "defense", "defence", "space", "drone", "drones"},
+		tickers:    []string{"ITA", "PPA", "XAR", "UFO"},
+	},
+	{
+		sector:     "Materials",
+		industries: []string{"Precious Metals", "Other Metals/Minerals"},
+		keywords:   []string{"gold", "silver", "copper", "lithium", "rare earth", "uranium", "metals", "mining"},
+		tickers:    []string{"GDX", "GDXJ", "COPX", "XME", "LIT", "URA", "URNM", "REMX"},
+	},
+	{
+		sector:     "Energy",
+		industries: []string{"Oil & Gas Production", "Oilfield Services/Equipment"},
+		keywords:   []string{"energy", "oil", "gas", "solar", "wind", "hydrogen", "clean power", "renewable"},
+		tickers:    []string{"TAN", "ICLN", "QCLN", "FAN", "PBW"},
+	},
+	{
+		sector:     "Health care",
+		industries: []string{"Biotechnology", "Medical Specialties"},
+		keywords:   []string{"biotech", "biotechnology", "genomics", "genomic", "medical", "health care", "healthcare"},
+		tickers:    []string{"XBI", "IBB", "ARKG"},
+	},
+	{
+		sector:     "Financials",
+		industries: []string{"Investment Banks/Brokers", "Finance/Rental/Leasing"},
+		keywords:   []string{"fintech", "blockchain", "crypto", "bitcoin"},
+		tickers:    []string{"BLOK", "BITQ", "FINX"},
+	},
+	{
+		sector:     "Communication services",
+		industries: []string{"Internet Software/Services", "Movies/Entertainment"},
+		keywords:   []string{"internet", "social media", "metaverse", "gaming", "video game", "streaming", "media"},
+		tickers:    []string{"SOCL", "HERO", "ESPO", "META"},
+	},
+	{
+		sector:     "Consumer discretionary",
+		industries: []string{"Internet Retail", "Motor Vehicles", "Specialty Stores"},
+		keywords:   []string{"ecommerce", "e-commerce", "retail", "consumer discretionary", "electric vehicle", "electric vehicles"},
+		tickers:    []string{"IBUY", "ONLN", "DRIV", "IDRV"},
+	},
+}
+
 type joinedSectorETF struct {
 	overview    types.ETFSectorOverview
 	performance types.ETFFundFlowPerformance
@@ -62,6 +132,7 @@ type joinedSectorETF struct {
 	class       string
 	sector      string
 	flow1Pct    float64
+	flow3Pct    float64
 	flowPrior2  float64
 	flowAccel   float64
 	perf        types.RotationPerformance
@@ -166,7 +237,7 @@ func screenDailyMarketRotation(screener MarketDataScreener, db databaseStore, op
 		},
 		BriefInstructions: []string{
 			"Use the precomputed values and rankings exactly; do not recalculate or reorder them.",
-			"Start with the 1M sector fund-flow landscape, then performance alignment and divergences.",
+			"Start with the 1M/3M sector fund-flow landscape, then performance alignment and divergences.",
 			"Cover broad-sector rotations, subsector rotations, performance-led opportunities, and zero to five stock candidates.",
 			"Describe ETF product flows, never direct stock-level institutional flows.",
 			"End with data-quality, exclusion, and invalidation notes.",
@@ -231,7 +302,7 @@ func joinAndFilterSectorETFs(overviews []types.ETFSectorOverview, performances [
 			continue
 		}
 		class := "subsector"
-		sector := canonicalETFSector(row.Focus)
+		sector := canonicalETFSector(row)
 		if broadSector, ok := broadSectorETFs[strings.ToUpper(row.Ticker)]; ok {
 			class = "broad"
 			sector = broadSector
@@ -246,6 +317,7 @@ func joinAndFilterSectorETFs(overviews []types.ETFSectorOverview, performances [
 		result = append(result, joinedSectorETF{
 			overview: row, performance: perf, flows: flow, class: class, sector: sector,
 			flow1Pct:   100 * flow1 / aum,
+			flow3Pct:   100 * flow3 / aum,
 			flowPrior2: 100 * ((flow3 - flow1) / 2) / aum,
 			flowAccel:  100 * (flow1 - ((flow3 - flow1) / 2)) / aum,
 			perf:       rotationPerformance(perf.Change, perf.OneWeek, perf.OneMonth, perf.ThreeMonths, perf.SixMonths, perf.OneYear),
@@ -263,9 +335,6 @@ func exclusionReason(row types.ETFSectorOverview, flow types.ETFFundFlows) strin
 	}
 	if !strings.EqualFold(row.AssetClass, "Equity") {
 		return "non_equity"
-	}
-	if strings.EqualFold(row.Focus, "Theme") {
-		return "thematic"
 	}
 	name := strings.ToLower(row.Fund + " " + row.Ticker)
 	for _, token := range []string{" leveraged", " inverse", " ultra", "ultrapro", " bull ", " bear ", "daily ", " daily", " 2x", " 3x", "-2x", "-3x", "single-stock", "single stock"} {
@@ -285,13 +354,49 @@ func isUSExchange(exchange string) bool {
 	}
 }
 
-func canonicalETFSector(focus string) string {
+func canonicalETFSector(row types.ETFSectorOverview) string {
+	if strings.EqualFold(row.Focus, "Theme") {
+		if mapping, ok := thematicMappingForETF(row.Ticker, row.Fund); ok {
+			return mapping.sector
+		}
+		return "Thematic"
+	}
 	for _, sector := range []string{"Communication services", "Consumer discretionary", "Consumer staples", "Energy", "Financials", "Health care", "Industrials", "Information technology", "Materials", "Real estate", "Utilities"} {
-		if strings.EqualFold(focus, sector) {
+		if strings.EqualFold(row.Focus, sector) {
 			return sector
 		}
 	}
 	return ""
+}
+
+func thematicMappingForETF(ticker, fund string) (thematicETFMapping, bool) {
+	upperTicker := strings.ToUpper(strings.TrimSpace(ticker))
+	searchText := " " + strings.ToLower(fund+" "+ticker) + " "
+	for _, mapping := range thematicETFMappings {
+		for _, candidate := range mapping.tickers {
+			if upperTicker == candidate {
+				return mapping, true
+			}
+		}
+		for _, keyword := range mapping.keywords {
+			if strings.Contains(searchText, keyword) {
+				return mapping, true
+			}
+		}
+	}
+	return thematicETFMapping{}, false
+}
+
+func mappedIndustriesForETF(row joinedSectorETF) []string {
+	if industries := subsectorIndustryHints[strings.ToUpper(row.overview.Ticker)]; len(industries) > 0 {
+		return industries
+	}
+	if strings.EqualFold(row.overview.Focus, "Theme") {
+		if mapping, ok := thematicMappingForETF(row.overview.Ticker, row.overview.Fund); ok {
+			return mapping.industries
+		}
+	}
+	return nil
 }
 
 func aggregateSectorFlows(etfs []joinedSectorETF) []types.SectorFundFlowSummary {
@@ -327,13 +432,14 @@ func aggregateSectorFlows(etfs []joinedSectorETF) []types.SectorFundFlowSummary 
 		broadPriorFlow := (group.broadFlow3 - group.broadFlow1) / 2
 		subPriorFlow := (group.subFlow3 - group.subFlow1) / 2
 		flowPct := safePercent(group.flow1, group.aum)
+		threeMonthFlowPct := safePercent(group.flow3, group.aum)
 		priorPct := safePercent(priorFlow, group.aum)
 		broadPerf := weightedPerformance(group.broad)
 		result = append(result, types.SectorFundFlowSummary{
 			Sector: group.sector, ETFCount: len(group.etfs), BroadETFCount: len(group.broad), SubsectorETFCount: len(group.subsector),
 			PositiveFlowETFCount: group.positive, PositiveFlowBreadthPercent: round(safePercent(float64(group.positive), float64(len(group.etfs))), 1),
 			CombinedAUMUSD: round(group.aum, 0), OneMonthFlowUSD: round(group.flow1, 0), ThreeMonthFlowUSD: round(group.flow3, 0),
-			OneMonthFlowPercentAUM: round(flowPct, 3), PriorTwoMonthMonthlyFlowUSD: round(priorFlow, 0),
+			OneMonthFlowPercentAUM: round(flowPct, 3), ThreeMonthFlowPercentAUM: round(threeMonthFlowPct, 3), PriorTwoMonthMonthlyFlowUSD: round(priorFlow, 0),
 			PriorTwoMonthMonthlyPercentAUM: round(priorPct, 3), FlowAccelerationPercentAUM: round(flowPct-priorPct, 3),
 			BroadOneMonthFlowUSD: round(group.broadFlow1, 0), SubsectorOneMonthFlowUSD: round(group.subFlow1, 0),
 			BroadFlowAccelerationPercentAUM:     round(safePercent(group.broadFlow1-broadPriorFlow, group.broadAUM), 3),
@@ -344,8 +450,14 @@ func aggregateSectorFlows(etfs []joinedSectorETF) []types.SectorFundFlowSummary 
 			LargestContributors:      contributions(group.etfs, true), LargestDetractors: contributions(group.etfs, false),
 		})
 	}
-	sort.Slice(result, func(i, j int) bool { return result[i].OneMonthFlowPercentAUM > result[j].OneMonthFlowPercentAUM })
+	sort.Slice(result, func(i, j int) bool {
+		return sectorFlowSortScore(result[i]) > sectorFlowSortScore(result[j])
+	})
 	return result
+}
+
+func sectorFlowSortScore(row types.SectorFundFlowSummary) float64 {
+	return 0.5*row.OneMonthFlowPercentAUM + 0.5*row.ThreeMonthFlowPercentAUM
 }
 
 func applySectorFlowTransitions(rows []types.SectorFundFlowSummary, previous *marketRotationSnapshot) {
@@ -491,9 +603,10 @@ func buildBroadSectorSignals(flows []types.SectorFundFlowSummary, previous *mark
 		if !aligned || setup == "unconfirmed" {
 			continue
 		}
-		score := 100 * (0.35*percentileRank(flowMetric(flows, func(x types.SectorFundFlowSummary) float64 { return x.OneMonthFlowPercentAUM }), row.OneMonthFlowPercentAUM) +
+		score := 100 * (0.20*percentileRank(flowMetric(flows, func(x types.SectorFundFlowSummary) float64 { return x.OneMonthFlowPercentAUM }), row.OneMonthFlowPercentAUM) +
+			0.20*percentileRank(flowMetric(flows, func(x types.SectorFundFlowSummary) float64 { return x.ThreeMonthFlowPercentAUM }), row.ThreeMonthFlowPercentAUM) +
 			0.25*percentileRank(flowMetric(flows, func(x types.SectorFundFlowSummary) float64 { return x.FlowAccelerationPercentAUM }), row.FlowAccelerationPercentAUM) +
-			0.40*percentileRank(accels, perf.Acceleration))
+			0.35*percentileRank(accels, perf.Acceleration))
 		result = append(result, types.SectorRotationSignal{Sector: row.Sector, Setup: setup, Score: round(score, 1), Transition: sectorTransition(previous, row.Sector, score), FlowTrend: row.FlowTrend, Performance: perf})
 	}
 	sort.Slice(result, func(i, j int) bool { return result[i].Score > result[j].Score })
@@ -518,11 +631,14 @@ func buildSubsectorSignals(etfs []joinedSectorETF, previous *marketRotationSnaps
 		if setup == "unconfirmed" {
 			continue
 		}
-		score := 100 * (0.35*percentileRank(etfMetric(etfs, func(x joinedSectorETF) float64 { return x.flow1Pct }), row.flow1Pct) + 0.25*percentileRank(etfMetric(etfs, func(x joinedSectorETF) float64 { return x.flowAccel }), row.flowAccel) + 0.40*percentileRank(accels, row.perf.Acceleration))
+		score := 100 * (0.20*percentileRank(etfMetric(etfs, func(x joinedSectorETF) float64 { return x.flow1Pct }), row.flow1Pct) +
+			0.20*percentileRank(etfMetric(etfs, func(x joinedSectorETF) float64 { return x.flow3Pct }), row.flow3Pct) +
+			0.25*percentileRank(etfMetric(etfs, func(x joinedSectorETF) float64 { return x.flowAccel }), row.flowAccel) +
+			0.35*percentileRank(accels, row.perf.Acceleration))
 		result = append(result, types.SubsectorRotationSignal{
-			Ticker: row.overview.Ticker, Fund: row.overview.Fund, Sector: row.sector, MappedIndustries: subsectorIndustryHints[strings.ToUpper(row.overview.Ticker)],
+			Ticker: row.overview.Ticker, Fund: row.overview.Fund, Sector: row.sector, MappedIndustries: mappedIndustriesForETF(row),
 			Setup: setup, Score: round(score, 1), Transition: subsectorTransition(previous, row.overview.Ticker, score), OneMonthFlowUSD: round(*row.flows.OneMonth, 0),
-			FlowPercentAUM: round(row.flow1Pct, 3), FlowAcceleration: round(row.flowAccel, 3), Performance: row.perf,
+			FlowPercentAUM: round(row.flow1Pct, 3), ThreeMonthFlowPercentAUM: round(row.flow3Pct, 3), FlowAcceleration: round(row.flowAccel, 3), Performance: row.perf,
 		})
 	}
 	sort.Slice(result, func(i, j int) bool { return result[i].Score > result[j].Score })
@@ -678,6 +794,10 @@ func scoreIndustryStocks(industry industryAnalysis, overviews []types.USAIndustr
 			continue
 		}
 		setup := setupType(row.shape, percentileRank(sixMonths, row.shape.SixMonths), percentileRank(accels, row.shape.Acceleration), percentileRank(threeMonths, row.shape.ThreeMonths))
+		if row.shape.ThreeMonths <= 0 {
+			rejected["three_month_performance_non_positive"]++
+			continue
+		}
 		if row.shape.OneWeek <= 0 || row.shape.OneMonth <= 0 || row.shape.Acceleration <= 0 || setup == "unconfirmed" {
 			rejected["unconfirmed_return_shape"]++
 			continue
@@ -693,35 +813,17 @@ func scoreIndustryStocks(industry industryAnalysis, overviews []types.USAIndustr
 			Lane: industry.signal.Lane, Setup: setup, Score: round(score, 1), Transition: stockTransition(previous, row.overview.Ticker, score),
 			MarketCapUSD: round(*row.overview.MarketCap, 0), DailyTurnoverUSD: round(row.turnover, 0), MonthlyVolatility: round(row.vol, 3),
 			EPSGrowthYoY: row.overview.EPSDilutedGrowthYoYTTM, AnalystRating: row.overview.AnalystRating, Performance: row.shape,
-			Invalidation: "The setup loses confirmation if 1W or 1M performance turns non-positive, return acceleration turns negative, or its sector/industry lane loses confirmation.",
+			Invalidation: "The setup loses confirmation if 1W, 1M, or 3M performance turns non-positive, return acceleration turns negative, or its sector/industry lane loses confirmation.",
 		})
 	}
 	return result
 }
 
 func selectIndustryDrilldowns(industries []industryAnalysis) []industryAnalysis {
-	result := make([]industryAnalysis, 0, maxIndustryDrilldowns)
-	lanes := []string{"broad_sector_confirmed", "subsector_rotation", "performance_led"}
-	seen := make(map[string]bool)
-	for _, lane := range lanes {
-		for _, row := range industries {
-			if row.signal.Lane == lane && !seen[row.signal.Industry] {
-				result = append(result, row)
-				seen[row.signal.Industry] = true
-				break
-			}
-		}
+	if len(industries) <= maxIndustryDrilldowns {
+		return append([]industryAnalysis(nil), industries...)
 	}
-	for _, row := range industries {
-		if len(result) >= maxIndustryDrilldowns {
-			break
-		}
-		if !seen[row.signal.Industry] {
-			result = append(result, row)
-			seen[row.signal.Industry] = true
-		}
-	}
-	return result
+	return append([]industryAnalysis(nil), industries[:maxIndustryDrilldowns]...)
 }
 
 func topIndustrySignals(industries []industryAnalysis, limit int) []types.IndustryRotationSignal {

--- a/pkg/mdata/market_rotation_test.go
+++ b/pkg/mdata/market_rotation_test.go
@@ -29,12 +29,40 @@ func TestJoinAndFilterSectorETFsExcludesUnsafeProducts(t *testing.T) {
 	}
 
 	joined, excluded := joinAndFilterSectorETFs(overviews, performances, flows)
-	require.Len(t, joined, 2)
+	require.Len(t, joined, 3)
 	require.Equal(t, "broad", joined[0].class)
 	require.Equal(t, "subsector", joined[1].class)
+	require.Equal(t, "subsector", joined[2].class)
+	require.Equal(t, "Information technology", joined[2].sector)
+	require.ElementsMatch(t, []string{"Semiconductors", "Packaged Software"}, mappedIndustriesForETF(joined[2]))
 	require.Equal(t, 1, excluded["leveraged_inverse_or_single_stock"])
 	require.Equal(t, 1, excluded["foreign_listing"])
-	require.Equal(t, 1, excluded["thematic"])
+	require.Zero(t, excluded["thematic"])
+}
+
+func TestThemeETFsMapToEconomicSectorsWhenPossible(t *testing.T) {
+	tests := []struct {
+		ticker     string
+		fund       string
+		wantSector string
+		wantHints  []string
+	}{
+		{"SMH", "VanEck Semiconductor ETF", "Information technology", []string{"Semiconductors"}},
+		{"AIQ", "Global X Artificial Intelligence & Technology ETF", "Information technology", []string{"Semiconductors", "Packaged Software"}},
+		{"ITA", "iShares U.S. Aerospace & Defense ETF", "Industrials", []string{"Aerospace & Defense"}},
+		{"URA", "Global X Uranium ETF", "Materials", []string{"Precious Metals", "Other Metals/Minerals"}},
+		{"ARKG", "ARK Genomic Revolution ETF", "Health care", []string{"Biotechnology", "Medical Specialties"}},
+		{"MISC", "Miscellaneous Future Themes ETF", "Thematic", nil},
+	}
+
+	for _, test := range tests {
+		t.Run(test.ticker, func(t *testing.T) {
+			overview := sectorOverview(strings.ToLower(test.ticker), test.ticker, test.fund, "NASDAQ", "Theme", 100)
+			require.Equal(t, test.wantSector, canonicalETFSector(overview))
+			joined := joinedSectorETF{overview: overview}
+			require.ElementsMatch(t, test.wantHints, mappedIndustriesForETF(joined))
+		})
+	}
 }
 
 func TestAggregateSectorFlowsSeparatesBroadAndSubsector(t *testing.T) {
@@ -47,11 +75,24 @@ func TestAggregateSectorFlowsSeparatesBroadAndSubsector(t *testing.T) {
 	require.Equal(t, "Financials", row.Sector)
 	require.InDelta(t, 8, row.OneMonthFlowUSD, 0.001)
 	require.InDelta(t, 5.333, row.OneMonthFlowPercentAUM, 0.001)
+	require.InDelta(t, 9.333, row.ThreeMonthFlowPercentAUM, 0.001)
 	require.InDelta(t, 7.5, row.BroadFlowAccelerationPercentAUM, 0.001)
 	require.InDelta(t, -5, row.SubsectorFlowAccelerationPercentAUM, 0.001)
 	require.Equal(t, "broad_inflow_subsector_outflow", row.BroadSubsectorRelationship)
 	require.Equal(t, "XLF", row.LargestContributors[0].Ticker)
 	require.Equal(t, "KBWB", row.LargestDetractors[0].Ticker)
+}
+
+func TestAggregateSectorFlowsSortsByOneAndThreeMonthFlowPercentAUM(t *testing.T) {
+	shortBurst := joinedETFForTest("XLE", "broad", 100, 12, 12)
+	shortBurst.sector = "Energy"
+	sustained := joinedETFForTest("XLK", "broad", 100, 8, 30)
+	sustained.sector = "Information technology"
+
+	rows := aggregateSectorFlows([]joinedSectorETF{shortBurst, sustained})
+	require.Len(t, rows, 2)
+	require.Equal(t, "Information technology", rows[0].Sector)
+	require.Equal(t, "Energy", rows[1].Sector)
 }
 
 func TestIndustryCrosswalkCoversMixedTradingViewSectors(t *testing.T) {
@@ -151,9 +192,27 @@ func TestScreenDailyMarketRotationReturnsOnlyQualifiedStocks(t *testing.T) {
 	for _, stock := range brief.StockCandidates {
 		require.GreaterOrEqual(t, stock.MarketCapUSD, 2_000_000_000.0)
 		require.GreaterOrEqual(t, stock.DailyTurnoverUSD, 20_000_000.0)
+		require.Greater(t, stock.Performance.ThreeMonths, 0.0)
 		require.NotEqual(t, "LOWCAP", stock.Ticker)
+		require.NotEqual(t, "NEG3M", stock.Ticker)
 	}
 	require.Greater(t, brief.RejectedStockCounts["market_cap_below_2b"], 0)
+	require.Greater(t, brief.RejectedStockCounts["three_month_performance_non_positive"], 0)
+}
+
+func TestSelectIndustryDrilldownsUsesTopThreeSortedIndustries(t *testing.T) {
+	industries := []industryAnalysis{
+		{signal: types.IndustryRotationSignal{Industry: "Semiconductors", Lane: "subsector_rotation", Score: 95}},
+		{signal: types.IndustryRotationSignal{Industry: "Packaged Software", Lane: "performance_led", Score: 90}},
+		{signal: types.IndustryRotationSignal{Industry: "Aerospace & Defense", Lane: "broad_sector_confirmed", Score: 85}},
+		{signal: types.IndustryRotationSignal{Industry: "Major Banks", Lane: "broad_sector_confirmed", Score: 80}},
+	}
+
+	selected := selectIndustryDrilldowns(industries)
+	require.Len(t, selected, 3)
+	require.Equal(t, "Semiconductors", selected[0].signal.Industry)
+	require.Equal(t, "Packaged Software", selected[1].signal.Industry)
+	require.Equal(t, "Aerospace & Defense", selected[2].signal.Industry)
 }
 
 type rotationTestScreener struct {
@@ -260,8 +319,8 @@ func industryPerformance(id, industry string, day, week, month, three, six, year
 }
 
 func makeTestStockOverviews() []types.USAIndustryStockOverview {
-	result := make([]types.USAIndustryStockOverview, 0, 6)
-	for i, ticker := range []string{"BANKA", "BANKB", "BANKC", "BANKD", "BANKE", "LOWCAP"} {
+	result := make([]types.USAIndustryStockOverview, 0, 7)
+	for i, ticker := range []string{"BANKA", "NEG3M", "BANKB", "BANKC", "BANKD", "BANKE", "LOWCAP"} {
 		marketCap := 10_000_000_000.0 + float64(i)*1_000_000_000
 		if ticker == "LOWCAP" {
 			marketCap = 500_000_000
@@ -273,12 +332,15 @@ func makeTestStockOverviews() []types.USAIndustryStockOverview {
 }
 
 func makeTestStockPerformance() []types.USAIndustryStockPerformance {
-	result := make([]types.USAIndustryStockPerformance, 0, 6)
-	for i, ticker := range []string{"BANKA", "BANKB", "BANKC", "BANKD", "BANKE", "LOWCAP"} {
+	result := make([]types.USAIndustryStockPerformance, 0, 7)
+	for i, ticker := range []string{"BANKA", "NEG3M", "BANKB", "BANKC", "BANKD", "BANKE", "LOWCAP"} {
 		day := 0.1
 		week := 2.0 + float64(i)/10
 		month := 5.0 + float64(i)
 		three, six, year := 4.0, -3.0, -2.0
+		if ticker == "NEG3M" {
+			three = -1.0
+		}
 		volatility := 1.0 + float64(i)/10
 		result = append(result, types.USAIndustryStockPerformance{ID: strings.ToLower(ticker), Ticker: ticker, Change: &day, OneWeek: &week, OneMonth: &month, ThreeMonths: &three, SixMonths: &six, OneYear: &year, VolatilityOneMonth: &volatility})
 	}

--- a/pkg/types/market_rotation.go
+++ b/pkg/types/market_rotation.go
@@ -1,7 +1,7 @@
 package types
 
 // MarketRotationMethodologyVersion changes whenever scoring or classification semantics change.
-const MarketRotationMethodologyVersion = "1.0.0"
+const MarketRotationMethodologyVersion = "1.4.0"
 
 // ETFContribution explains which ETF materially affected a sector's aggregate flow.
 type ETFContribution struct {
@@ -35,6 +35,7 @@ type SectorFundFlowSummary struct {
 	OneMonthFlowUSD                     float64             `json:"one_month_flow_usd"`
 	ThreeMonthFlowUSD                   float64             `json:"three_month_flow_usd"`
 	OneMonthFlowPercentAUM              float64             `json:"one_month_flow_percent_aum"`
+	ThreeMonthFlowPercentAUM            float64             `json:"three_month_flow_percent_aum"`
 	PriorTwoMonthMonthlyFlowUSD         float64             `json:"prior_two_month_monthly_flow_usd"`
 	PriorTwoMonthMonthlyPercentAUM      float64             `json:"prior_two_month_monthly_percent_aum"`
 	FlowAccelerationPercentAUM          float64             `json:"flow_acceleration_percent_aum"`
@@ -63,17 +64,18 @@ type SectorRotationSignal struct {
 
 // SubsectorRotationSignal describes an independently confirmed industry/subsector ETF move.
 type SubsectorRotationSignal struct {
-	Ticker           string              `json:"ticker"`
-	Fund             string              `json:"fund"`
-	Sector           string              `json:"sector"`
-	MappedIndustries []string            `json:"mapped_industries,omitempty"`
-	Setup            string              `json:"setup"`
-	Score            float64             `json:"score"`
-	Transition       string              `json:"transition"`
-	OneMonthFlowUSD  float64             `json:"one_month_flow_usd"`
-	FlowPercentAUM   float64             `json:"one_month_flow_percent_aum"`
-	FlowAcceleration float64             `json:"flow_acceleration_percent_aum"`
-	Performance      RotationPerformance `json:"performance"`
+	Ticker                   string              `json:"ticker"`
+	Fund                     string              `json:"fund"`
+	Sector                   string              `json:"sector"`
+	MappedIndustries         []string            `json:"mapped_industries,omitempty"`
+	Setup                    string              `json:"setup"`
+	Score                    float64             `json:"score"`
+	Transition               string              `json:"transition"`
+	OneMonthFlowUSD          float64             `json:"one_month_flow_usd"`
+	FlowPercentAUM           float64             `json:"one_month_flow_percent_aum"`
+	ThreeMonthFlowPercentAUM float64             `json:"three_month_flow_percent_aum"`
+	FlowAcceleration         float64             `json:"flow_acceleration_percent_aum"`
+	Performance              RotationPerformance `json:"performance"`
 }
 
 // IndustryRotationSignal is an industry selected for stock drill-down.


### PR DESCRIPTION
Current screener signals are excluding thematic etfs from trading view, and is changing too often to allow us to stay in a position for long. We give more weight to 3m funds flow / AUM to slow down the speed of the signal generation.