### PR TITLE
feat(ui): make summary page more informative and fix gdrive auth issues

### DIFF
--- a/internal/backup/gdrive.go
+++ b/internal/backup/gdrive.go
@@ -3,6 +3,7 @@ package backup
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -207,12 +208,42 @@ func (g *GDriveBackupSource) getOAuthClient(ctx context.Context, config *oauth2.
 				}
 			} else {
 				fmt.Printf("GDrive: Failed to refresh token: %v. Requesting new token...\n", err)
+				if isInvalidGrant(err) {
+					expiredFile, archiveErr := archiveExpiredToken(tokFile)
+					if archiveErr != nil {
+						fmt.Printf("GDrive: Warning - failed to archive expired token: %v\n", archiveErr)
+					} else {
+						fmt.Printf("GDrive: Archived expired token as %s\n", expiredFile)
+					}
+				}
 				tok = g.getTokenFromWeb(ctx, config)
 				g.saveToken(tokFile, tok)
 			}
 		}
 	}
 	return config.Client(ctx, tok)
+}
+
+func isInvalidGrant(err error) bool {
+	var retrieveErr *oauth2.RetrieveError
+	return errors.As(err, &retrieveErr) && retrieveErr.ErrorCode == "invalid_grant"
+}
+
+func archiveExpiredToken(tokenFile string) (string, error) {
+	expiredFile := tokenFile + ".expired"
+	if _, err := os.Stat(expiredFile); err == nil {
+		previousExpiredFile := fmt.Sprintf("%s.%s", expiredFile, time.Now().UTC().Format("20060102-150405.000000000"))
+		if err := os.Rename(expiredFile, previousExpiredFile); err != nil {
+			return "", fmt.Errorf("archive previous expired token: %w", err)
+		}
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("inspect previous expired token: %w", err)
+	}
+
+	if err := os.Rename(tokenFile, expiredFile); err != nil {
+		return "", fmt.Errorf("archive token: %w", err)
+	}
+	return expiredFile, nil
 }
 
 // getTokenFromWeb requests a token from the web, then returns the retrieved token.

--- a/internal/backup/gdrive_test.go
+++ b/internal/backup/gdrive_test.go
@@ -1,0 +1,56 @@
+package backup
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+func TestIsInvalidGrant(t *testing.T) {
+	assert.True(t, isInvalidGrant(&oauth2.RetrieveError{ErrorCode: "invalid_grant"}))
+	assert.False(t, isInvalidGrant(&oauth2.RetrieveError{ErrorCode: "temporarily_unavailable"}))
+	assert.False(t, isInvalidGrant(errors.New("network unavailable")))
+}
+
+func TestArchiveExpiredToken(t *testing.T) {
+	tempDir := t.TempDir()
+	tokenFile := filepath.Join(tempDir, "token.json")
+	require.NoError(t, os.WriteFile(tokenFile, []byte("expired-token"), 0600))
+
+	expiredFile, err := archiveExpiredToken(tokenFile)
+	require.NoError(t, err)
+	assert.Equal(t, tokenFile+".expired", expiredFile)
+	assert.NoFileExists(t, tokenFile)
+	assert.FileExists(t, expiredFile)
+
+	contents, err := os.ReadFile(expiredFile)
+	require.NoError(t, err)
+	assert.Equal(t, "expired-token", string(contents))
+}
+
+func TestArchiveExpiredTokenPreservesPreviousArchive(t *testing.T) {
+	tempDir := t.TempDir()
+	tokenFile := filepath.Join(tempDir, "token.json")
+	expiredFile := tokenFile + ".expired"
+	require.NoError(t, os.WriteFile(tokenFile, []byte("new-expired-token"), 0600))
+	require.NoError(t, os.WriteFile(expiredFile, []byte("previous-expired-token"), 0600))
+
+	_, err := archiveExpiredToken(tokenFile)
+	require.NoError(t, err)
+
+	contents, err := os.ReadFile(expiredFile)
+	require.NoError(t, err)
+	assert.Equal(t, "new-expired-token", string(contents))
+
+	previousArchives, err := filepath.Glob(expiredFile + ".*")
+	require.NoError(t, err)
+	require.Len(t, previousArchives, 1)
+	previousContents, err := os.ReadFile(previousArchives[0])
+	require.NoError(t, err)
+	assert.Equal(t, "previous-expired-token", string(previousContents))
+}

--- a/web/ui/src/components/Analytics/MetricsTable.tsx
+++ b/web/ui/src/components/Analytics/MetricsTable.tsx
@@ -17,7 +17,12 @@ import {
   type MRT_ColumnDef,
   useMantineReactTable,
 } from "mantine-react-table";
-import { IconDownload, IconTrash, IconUpload } from "@tabler/icons-react";
+import {
+  IconDownload,
+  IconPencil,
+  IconTrash,
+  IconUpload,
+} from "@tabler/icons-react";
 import { getUrl } from "../../utils/url";
 import { TimestampedMetrics, MetricsJob } from "./types";
 import { withRollingVolatility, VolatilityMethod } from "./volatility";
@@ -35,6 +40,13 @@ interface DeleteMetricsResponse {
   failures: string[];
 }
 
+interface EditableMetricValues {
+  mv: number;
+  pricePaid: number;
+  totalDividends: number;
+  irrPercent: number;
+}
+
 const MetricsTable: React.FC<MetricsTableProps> = ({
   volatilityMethod,
   setVolatilityMethod,
@@ -44,6 +56,10 @@ const MetricsTable: React.FC<MetricsTableProps> = ({
   const theme = useMantineTheme();
 
   const [deleteModalOpen, setDeleteModalOpen] = useState(false);
+  const [editModalOpen, setEditModalOpen] = useState(false);
+  const [isUpdatingMetric, setIsUpdatingMetric] = useState(false);
+  const [editableMetric, setEditableMetric] =
+    useState<EditableMetricValues | null>(null);
   const [selectedMetric, setSelectedMetric] =
     useState<TimestampedMetrics | null>(null);
   const [selectedMetrics, setSelectedMetrics] = useState<TimestampedMetrics[]>(
@@ -211,6 +227,78 @@ const MetricsTable: React.FC<MetricsTableProps> = ({
       deleteMetrics([selectedMetric.timestamp]);
     }
     setDeleteModalOpen(false);
+  };
+
+  const updateMetric = async () => {
+    if (!selectedMetric || !editableMetric) return;
+
+    const values = Object.values(editableMetric);
+    if (values.some((value) => !Number.isFinite(value))) {
+      notifications.show({
+        color: "red",
+        title: "Invalid Values",
+        message: "All metric values must be valid numbers.",
+      });
+      return;
+    }
+
+    setIsUpdatingMetric(true);
+    try {
+      const bookFilter =
+        selectedBookFilter === "None" ? "" : selectedBookFilter || "";
+      const url = bookFilter
+        ? getUrl(
+            `/api/v1/historical/metrics?book_filter=${encodeURIComponent(
+              bookFilter,
+            )}`,
+          )
+        : getUrl("/api/v1/historical/metrics");
+      const response = await fetch(url, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          timestamp: selectedMetric.timestamp,
+          metrics: {
+            mv: editableMetric.mv,
+            pricePaid: editableMetric.pricePaid,
+            totalDividends: editableMetric.totalDividends,
+            irr: editableMetric.irrPercent / 100,
+          },
+        }),
+      });
+
+      if (!response.ok) {
+        const errorPayload = await response
+          .json()
+          .catch(() => ({ message: `Update failed (${response.status})` }));
+        throw new Error(
+          errorPayload?.message || `Update failed (${response.status})`,
+        );
+      }
+
+      notifications.show({
+        title: "Success",
+        message: "Historical metrics record updated successfully",
+        color: "green",
+      });
+      setEditModalOpen(false);
+      setEditableMetric(null);
+      setSelectedMetric(null);
+      table.resetRowSelection();
+      await refetch();
+    } catch (error: unknown) {
+      const message =
+        error instanceof Error ? error.message : "Unable to update record";
+      notifications.show({
+        color: "red",
+        title: "Update Failed",
+        message,
+      });
+    } finally {
+      setIsUpdatingMetric(false);
+    }
   };
 
   // Upload metrics CSV file
@@ -542,6 +630,27 @@ const MetricsTable: React.FC<MetricsTableProps> = ({
             <Button
               onClick={() => {
                 const selectedRows = table.getSelectedRowModel().rows;
+                if (selectedRows.length !== 1) return;
+
+                const metric = selectedRows[0].original;
+                setSelectedMetric(metric);
+                setEditableMetric({
+                  mv: metric.metrics.mv,
+                  pricePaid: metric.metrics.pricePaid,
+                  totalDividends: metric.metrics.totalDividends,
+                  irrPercent: metric.metrics.irr * 100,
+                });
+                setEditModalOpen(true);
+              }}
+              leftSection={<IconPencil size={18} />}
+              variant="outline"
+              disabled={table.getSelectedRowModel().rows.length !== 1}
+            >
+              Update Record
+            </Button>
+            <Button
+              onClick={() => {
+                const selectedRows = table.getSelectedRowModel().rows;
                 if (selectedRows.length === 1) {
                   // Single selection
                   setSelectedMetric(selectedRows[0].original);
@@ -621,6 +730,114 @@ const MetricsTable: React.FC<MetricsTableProps> = ({
             Delete
           </Button>
         </Group>
+      </Modal>
+
+      <Modal
+        opened={editModalOpen}
+        onClose={() => {
+          if (!isUpdatingMetric) {
+            setEditModalOpen(false);
+            setEditableMetric(null);
+          }
+        }}
+        title="Update Historical Metrics"
+        size="sm"
+        closeOnClickOutside={!isUpdatingMetric}
+        closeOnEscape={!isUpdatingMetric}
+      >
+        {selectedMetric && editableMetric ? (
+          <Stack gap="sm">
+            <Box>
+              <Text size="xs" c="dimmed">
+                Record date
+              </Text>
+              <Text fw={600}>
+                {new Date(selectedMetric.timestamp).toLocaleDateString()}
+              </Text>
+            </Box>
+            <NumberInput
+              label="Market Value"
+              value={editableMetric.mv}
+              onChange={(value) =>
+                setEditableMetric((current) =>
+                  current ? { ...current, mv: Number(value) } : current,
+                )
+              }
+              decimalScale={2}
+              thousandSeparator=","
+            />
+            <NumberInput
+              label="Price Paid"
+              value={editableMetric.pricePaid}
+              onChange={(value) =>
+                setEditableMetric((current) =>
+                  current
+                    ? { ...current, pricePaid: Number(value) }
+                    : current,
+                )
+              }
+              decimalScale={2}
+              thousandSeparator=","
+            />
+            <NumberInput
+              label="Total Dividends"
+              value={editableMetric.totalDividends}
+              onChange={(value) =>
+                setEditableMetric((current) =>
+                  current
+                    ? { ...current, totalDividends: Number(value) }
+                    : current,
+                )
+              }
+              decimalScale={2}
+              thousandSeparator=","
+            />
+            <NumberInput
+              label="IRR (%)"
+              value={editableMetric.irrPercent}
+              onChange={(value) =>
+                setEditableMetric((current) =>
+                  current
+                    ? { ...current, irrPercent: Number(value) }
+                    : current,
+                )
+              }
+              decimalScale={4}
+              suffix="%"
+            />
+            <Box>
+              <Text size="xs" c="dimmed">
+                Calculated P&amp;L
+              </Text>
+              <Text fw={600}>
+                $
+                {(
+                  editableMetric.mv -
+                  editableMetric.pricePaid +
+                  editableMetric.totalDividends
+                ).toLocaleString(undefined, {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                })}
+              </Text>
+            </Box>
+            <Group justify="flex-end" mt="xs">
+              <Button
+                variant="outline"
+                onClick={() => {
+                  setEditModalOpen(false);
+                  setEditableMetric(null);
+                }}
+                disabled={isUpdatingMetric}
+              >
+                Cancel
+              </Button>
+              <Button onClick={updateMetric} loading={isUpdatingMetric}>
+                Save Changes
+              </Button>
+            </Group>
+          </Stack>
+        ) : null}
       </Modal>
 
       <Box mt="xs">

--- a/web/ui/src/components/Position/PositionTable.tsx
+++ b/web/ui/src/components/Position/PositionTable.tsx
@@ -78,15 +78,19 @@ interface CachedPricesResponse {
 
 interface PositionLocationState {
   book?: unknown;
+  ccy?: unknown;
 }
 
-const getBookFromLocationState = (state: unknown) => {
-  if (!state || typeof state !== "object" || !("book" in state)) {
+const getFilterFromLocationState = (
+  state: unknown,
+  key: keyof PositionLocationState,
+) => {
+  if (!state || typeof state !== "object" || !(key in state)) {
     return null;
   }
 
-  const book = (state as PositionLocationState).book;
-  return typeof book === "string" && book ? book : null;
+  const value = (state as PositionLocationState)[key];
+  return typeof value === "string" && value ? value : null;
 };
 
 const isTBillTicker = (ticker: string) =>
@@ -201,18 +205,31 @@ const rowValueInSGD = (
 const PositionTable: React.FC = () => {
   const navigate = useNavigate();
   const location = useLocation();
-  const bookFromLocationState = getBookFromLocationState(location.state);
+  const bookFromLocationState = getFilterFromLocationState(
+    location.state,
+    "book",
+  );
+  const ccyFromLocationState = getFilterFromLocationState(
+    location.state,
+    "ccy",
+  );
   const refData = useSelector((state: RootState) => state.referenceData.data);
   const [filteredPositions, setFilteredPositions] = useState<PositionRow[]>([]);
   const [columnFilters, setColumnFilters] = useState<
     Array<{ id: string; value: unknown }>
-  >(() =>
-    bookFromLocationState ? [{ id: "Book", value: bookFromLocationState }] : [],
-  );
+  >(() => [
+    ...(bookFromLocationState
+      ? [{ id: "Book", value: bookFromLocationState }]
+      : []),
+    ...(ccyFromLocationState
+      ? [{ id: "Ccy", value: ccyFromLocationState }]
+      : []),
+  ]);
   const [globalFilter, setGlobalFilter] = useState("");
   const [priceLag, setPriceLag] = useState<"t-1" | "t-2">("t-1");
   const defaultTitleRef = useRef(document.title);
   const appliedBookFilterRef = useRef<string | null>(bookFromLocationState);
+  const appliedCcyFilterRef = useRef<string | null>(ccyFromLocationState);
 
   const {
     data: rawPositions = [],
@@ -308,6 +325,21 @@ const PositionTable: React.FC = () => {
       { id: "Book", value: bookFromLocationState },
     ]);
   }, [bookFromLocationState]);
+
+  useEffect(() => {
+    if (
+      !ccyFromLocationState ||
+      appliedCcyFilterRef.current === ccyFromLocationState
+    ) {
+      return;
+    }
+
+    appliedCcyFilterRef.current = ccyFromLocationState;
+    setColumnFilters((current) => [
+      ...current.filter((filter) => filter.id !== "Ccy"),
+      { id: "Ccy", value: ccyFromLocationState },
+    ]);
+  }, [ccyFromLocationState]);
 
   const groupedTargetTicker = (position: PositionRow) =>
     position.UnderlyingGroup || position.UnderlyingTicker || position.Ticker;

--- a/web/ui/src/components/Summary/MonthlyPortfolioActivityTable.tsx
+++ b/web/ui/src/components/Summary/MonthlyPortfolioActivityTable.tsx
@@ -1,0 +1,333 @@
+import React, { useState } from "react";
+import {
+  Box,
+  Collapse,
+  Group,
+  Loader,
+  Paper,
+  Table,
+  Text,
+  Title,
+  UnstyledButton,
+} from "@mantine/core";
+import { IconChevronRight } from "@tabler/icons-react";
+import type { ReferenceData } from "../../types";
+import type { MonthlyPortfolioActivity } from "./monthlyActivity";
+
+const numberStyle: React.CSSProperties = {
+  fontVariantNumeric: "tabular-nums",
+  fontFeatureSettings: '"tnum" 1',
+};
+
+const formatAmount = (value?: number) =>
+  value === undefined
+    ? "—"
+    : value.toLocaleString(undefined, {
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      });
+
+const formatNumber = (value: number, maximumFractionDigits = 2) =>
+  value.toLocaleString(undefined, {
+    minimumFractionDigits: 0,
+    maximumFractionDigits,
+  });
+
+const formatDate = (value: string) =>
+  new Date(`${value}T00:00:00`).toLocaleDateString();
+
+interface MonthlyPortfolioActivityTableProps {
+  rows: MonthlyPortfolioActivity[];
+  referenceData: ReferenceData | null;
+  isMetricsLoading: boolean;
+  areTradesLoading: boolean;
+  hasMetricsError: boolean;
+  hasTradeError: boolean;
+}
+
+const MonthlyPortfolioActivityTable: React.FC<
+  MonthlyPortfolioActivityTableProps
+> = ({
+  rows,
+  referenceData,
+  isMetricsLoading,
+  areTradesLoading,
+  hasMetricsError,
+  hasTradeError,
+}) => {
+  const [expandedMonths, setExpandedMonths] = useState<Set<string>>(new Set());
+
+  const toggleMonth = (monthKey: string) => {
+    setExpandedMonths((current) => {
+      const next = new Set(current);
+      if (next.has(monthKey)) {
+        next.delete(monthKey);
+      } else {
+        next.add(monthKey);
+      }
+      return next;
+    });
+  };
+
+  return (
+    <Paper withBorder p={{ base: "xs", sm: "md" }} radius="sm" mt="md">
+      <Group justify="space-between" mb="sm">
+        <Box>
+          <Title order={4} size="h5">
+            Past 12 Months
+          </Title>
+          <Text c="dimmed" size="xs">
+            Monthly portfolio performance and aggregated trading activity
+          </Text>
+        </Box>
+        {isMetricsLoading || areTradesLoading ? <Loader size="sm" /> : null}
+      </Group>
+
+      <Table.ScrollContainer minWidth={720}>
+        <Table
+          striped
+          highlightOnHover
+          withTableBorder
+          fz="sm"
+          horizontalSpacing="xs"
+          verticalSpacing="xs"
+        >
+          <Table.Thead>
+            <Table.Tr>
+              <Table.Th>Month</Table.Th>
+              <Table.Th style={{ textAlign: "right" }}>MTD P&amp;L</Table.Th>
+              <Table.Th style={{ textAlign: "right" }}>Dividends</Table.Th>
+              <Table.Th style={{ textAlign: "right" }}>Net CF</Table.Th>
+              <Table.Th style={{ textAlign: "right" }}>
+                Portfolio Market Value
+              </Table.Th>
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {rows.map((row) => {
+              const isExpanded = expandedMonths.has(row.monthKey);
+              const monthNetPricePaid = row.netCashFlow;
+
+              return (
+                <React.Fragment key={row.monthKey}>
+                  <Table.Tr>
+                    <Table.Td>
+                      <UnstyledButton
+                        onClick={() => toggleMonth(row.monthKey)}
+                        style={{ width: "100%" }}
+                        aria-expanded={isExpanded}
+                      >
+                        <Group gap="xs" wrap="nowrap">
+                          <IconChevronRight
+                            size={14}
+                            style={{
+                              flexShrink: 0,
+                              transform: isExpanded
+                                ? "rotate(90deg)"
+                                : "none",
+                            }}
+                          />
+                          <Text fw={600} size="sm">
+                            {row.monthLabel}
+                          </Text>
+                        </Group>
+                      </UnstyledButton>
+                    </Table.Td>
+                    <Table.Td
+                      style={{
+                        textAlign: "right",
+                        color:
+                          row.mtdPnl === undefined
+                            ? "var(--mantine-color-dimmed)"
+                            : row.mtdPnl < 0
+                              ? "var(--mantine-color-red-6)"
+                              : "var(--mantine-color-green-6)",
+                        ...numberStyle,
+                      }}
+                    >
+                      {formatAmount(row.mtdPnl)}
+                    </Table.Td>
+                    <Table.Td
+                      style={{
+                        textAlign: "right",
+                        color:
+                          row.dividends === undefined
+                            ? "var(--mantine-color-dimmed)"
+                            : "var(--mantine-color-green-6)",
+                        ...numberStyle,
+                      }}
+                    >
+                      {formatAmount(row.dividends)}
+                    </Table.Td>
+                    <Table.Td
+                      style={{
+                        textAlign: "right",
+                        color:
+                          row.netCashFlow < 0
+                            ? "var(--mantine-color-red-6)"
+                            : undefined,
+                        ...numberStyle,
+                      }}
+                    >
+                      {formatAmount(row.netCashFlow)}
+                    </Table.Td>
+                    <Table.Td style={{ textAlign: "right", ...numberStyle }}>
+                      {formatAmount(row.marketValue)}
+                    </Table.Td>
+                  </Table.Tr>
+                  <Table.Tr>
+                    <Table.Td colSpan={5} p={0}>
+                      <Collapse in={isExpanded}>
+                        <Box p="xs">
+                          {hasTradeError ? (
+                            <Text c="red" size="sm">
+                              Trade data is unavailable.
+                            </Text>
+                          ) : areTradesLoading ? (
+                            <Text c="dimmed" size="sm">
+                              Loading trades…
+                            </Text>
+                          ) : row.trades.length === 0 ? (
+                            <Text c="dimmed" size="sm">
+                              No trades recorded for this month.
+                            </Text>
+                          ) : (
+                            <Table.ScrollContainer minWidth={560}>
+                              <Table
+                                withColumnBorders
+                                fz="sm"
+                                horizontalSpacing="xs"
+                                verticalSpacing="xs"
+                              >
+                                <Table.Thead>
+                                  <Table.Tr>
+                                    <Table.Th>Ticker</Table.Th>
+                                    <Table.Th>Name</Table.Th>
+                                    <Table.Th>Dt</Table.Th>
+                                    <Table.Th style={{ textAlign: "right" }}>
+                                      Bought
+                                    </Table.Th>
+                                    <Table.Th style={{ textAlign: "right" }}>
+                                      Sold
+                                    </Table.Th>
+                                    <Table.Th style={{ textAlign: "right" }}>
+                                      Net Quantity
+                                    </Table.Th>
+                                    <Table.Th style={{ textAlign: "right" }}>
+                                      Avg Transaction Price
+                                    </Table.Th>
+                                    <Table.Th style={{ textAlign: "right" }}>
+                                      Net Price Paid
+                                    </Table.Th>
+                                  </Table.Tr>
+                                </Table.Thead>
+                                <Table.Tbody>
+                                  {row.trades.map((trade) => {
+                                    const ref = referenceData?.[trade.ticker];
+                                    return (
+                                      <Table.Tr key={trade.ticker}>
+                                        <Table.Td>{trade.ticker}</Table.Td>
+                                        <Table.Td>
+                                          {ref?.name || trade.ticker}
+                                        </Table.Td>
+                                        <Table.Td>
+                                          {formatDate(trade.earliestTradeDate)}
+                                        </Table.Td>
+                                        <Table.Td
+                                          style={{
+                                            textAlign: "right",
+                                            ...numberStyle,
+                                          }}
+                                        >
+                                          {formatNumber(
+                                            trade.quantityBought,
+                                            4,
+                                          )}
+                                        </Table.Td>
+                                        <Table.Td
+                                          style={{
+                                            textAlign: "right",
+                                            ...numberStyle,
+                                          }}
+                                        >
+                                          {formatNumber(
+                                            trade.quantitySold,
+                                            4,
+                                          )}
+                                        </Table.Td>
+                                        <Table.Td
+                                          style={{
+                                            textAlign: "right",
+                                            ...numberStyle,
+                                          }}
+                                        >
+                                          {formatNumber(trade.netQuantity, 4)}
+                                        </Table.Td>
+                                        <Table.Td
+                                          style={{
+                                            textAlign: "right",
+                                            ...numberStyle,
+                                          }}
+                                        >
+                                          {formatNumber(trade.averagePrice, 4)}
+                                        </Table.Td>
+                                        <Table.Td
+                                          style={{
+                                            textAlign: "right",
+                                            ...numberStyle,
+                                            color:
+                                              trade.pricePaid < 0
+                                                ? "var(--mantine-color-red-6)"
+                                                : undefined,
+                                          }}
+                                        >
+                                          {formatAmount(trade.pricePaid)}
+                                        </Table.Td>
+                                      </Table.Tr>
+                                    );
+                                  })}
+                                </Table.Tbody>
+                                <Table.Tfoot>
+                                  <Table.Tr>
+                                    <Table.Th colSpan={7}>Month total</Table.Th>
+                                    <Table.Th
+                                      style={{
+                                        textAlign: "right",
+                                        color:
+                                          monthNetPricePaid < 0
+                                            ? "var(--mantine-color-red-6)"
+                                            : undefined,
+                                      }}
+                                    >
+                                      {formatAmount(monthNetPricePaid)}
+                                    </Table.Th>
+                                  </Table.Tr>
+                                </Table.Tfoot>
+                              </Table>
+                            </Table.ScrollContainer>
+                          )}
+                        </Box>
+                      </Collapse>
+                    </Table.Td>
+                  </Table.Tr>
+                </React.Fragment>
+              );
+            })}
+          </Table.Tbody>
+        </Table>
+      </Table.ScrollContainer>
+      {hasMetricsError ? (
+        <Text c="red" size="xs" mt="xs">
+          Historical portfolio metrics are unavailable.
+        </Text>
+      ) : null}
+      <Text c="dimmed" size="xs" mt="xs">
+        Monthly P&amp;L and dividends require a historical snapshot at or before
+        the start of the month. Net price paid includes trade FX, with sell
+        proceeds offsetting purchases.
+      </Text>
+    </Paper>
+  );
+};
+
+export default MonthlyPortfolioActivityTable;

--- a/web/ui/src/components/Summary/SummaryView.tsx
+++ b/web/ui/src/components/Summary/SummaryView.tsx
@@ -26,8 +26,13 @@ import { useSelector } from "react-redux";
 import { useNavigate } from "react-router-dom";
 import { RootState } from "../../store";
 import { ReferenceDataItem } from "../../types";
+import type { Trade } from "../../types/blotter";
 import { getUrl } from "../../utils/url";
 import { IsSGGovies } from "../../utils/referenceData";
+import type { TimestampedMetrics } from "../Analytics/types";
+import MonthlyPortfolioActivityTable from "./MonthlyPortfolioActivityTable";
+import { buildMonthlyPortfolioActivity } from "./monthlyActivity";
+import { calculateHeadlinePnlMetrics } from "./summaryMetrics";
 
 interface Position {
   Ticker: string;
@@ -113,6 +118,53 @@ const numberStyle: React.CSSProperties = {
   fontFeatureSettings: '"tnum" 1',
 };
 
+const PeriodPnlHeadline: React.FC<{
+  label: string;
+  value?: number;
+  isLoading: boolean;
+  hasError: boolean;
+}> = ({ label, value, isLoading, hasError }) => (
+  <Box py={2}>
+    <Group gap={6} wrap="nowrap">
+      <Box
+        w={6}
+        h={6}
+        style={{
+          flexShrink: 0,
+          borderRadius: "50%",
+          background: `var(--mantine-color-${
+            value === undefined ? "gray" : value < 0 ? "red" : "green"
+          }-6)`,
+        }}
+      />
+      <Text c="dimmed" size="xs" fw={600} tt="uppercase" lts={0.4}>
+        {label}
+      </Text>
+    </Group>
+    {isLoading ? (
+      <Loader size="xs" mt={4} />
+    ) : value === undefined ? (
+      <>
+        <Text fw={600} size="md" c="dimmed" style={{ lineHeight: 1.25 }}>
+          —
+        </Text>
+        <Text c="dimmed" size="xs">
+          {hasError ? "Unavailable" : "Insufficient history"}
+        </Text>
+      </>
+    ) : (
+      <Text
+        fw={600}
+        size="md"
+        c={value < 0 ? "red" : "green"}
+        style={{ lineHeight: 1.25, ...numberStyle }}
+      >
+        {formatMoney(value, "SGD")}
+      </Text>
+    )}
+  </Box>
+);
+
 const inlineMetricStyle: React.CSSProperties = {
   ...numberStyle,
   display: "inline-flex",
@@ -195,7 +247,7 @@ const SummaryTable: React.FC<{
   };
   expandable?: boolean;
   onEditReferenceData?: (detail: SummaryDetail) => void;
-  onViewPositionsByBook?: (book: string) => void;
+  onViewPositions?: (label: string) => void;
 }> = ({
   title,
   rows,
@@ -203,7 +255,7 @@ const SummaryTable: React.FC<{
   defaultSort = null,
   expandable = false,
   onEditReferenceData,
-  onViewPositionsByBook,
+  onViewPositions,
 }) => {
   const [expandedRows, setExpandedRows] = useState<Set<string>>(new Set());
   const [sort, setSort] = useState<{
@@ -326,7 +378,7 @@ const SummaryTable: React.FC<{
             const isExpanded = expandedRows.has(row.label);
             const details = summarizeDetails(row.details || []);
             const canExpand = expandable && details.length > 0;
-            const canViewPositionsByBook = Boolean(onViewPositionsByBook);
+            const canViewPositions = Boolean(onViewPositions);
 
             return (
               <React.Fragment key={row.label}>
@@ -352,9 +404,9 @@ const SummaryTable: React.FC<{
                           </Text>
                         </Group>
                       </UnstyledButton>
-                    ) : canViewPositionsByBook ? (
+                    ) : canViewPositions ? (
                       <UnstyledButton
-                        onClick={() => onViewPositionsByBook?.(row.label)}
+                        onClick={() => onViewPositions?.(row.label)}
                         style={{ width: "100%" }}
                       >
                         <Group gap={4} wrap="nowrap">
@@ -565,6 +617,50 @@ const SummaryView: React.FC = () => {
     enabled: uniqueTickers.length > 0,
   });
 
+  const {
+    data: historicalMetrics = [],
+    isLoading: isHistoricalMetricsLoading,
+    isError: hasHistoricalMetricsError,
+  } = useQuery<TimestampedMetrics[], Error>({
+    queryKey: ["historicalMetrics", "None"],
+    queryFn: async () => {
+      const resp = await fetch(getUrl("/api/v1/historical/metrics"));
+      if (!resp.ok) {
+        throw new Error("Failed to get historical metrics");
+      }
+      return resp.json();
+    },
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+
+  const headlinePnl = useMemo(
+    () => calculateHeadlinePnlMetrics(historicalMetrics),
+    [historicalMetrics],
+  );
+
+  const {
+    data: trades = [],
+    isLoading: areTradesLoading,
+    isError: hasTradesError,
+  } = useQuery<Trade[], Error>({
+    queryKey: ["trades"],
+    queryFn: async () => {
+      const resp = await fetch(getUrl("/api/v1/blotter/trade"));
+      if (!resp.ok) {
+        throw new Error("Failed to get trades");
+      }
+      return resp.json();
+    },
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+
+  const monthlyActivity = useMemo(
+    () => buildMonthlyPortfolioActivity(historicalMetrics, trades),
+    [historicalMetrics, trades],
+  );
+
   const hasCachedMetrics = Boolean(cachedPricesData?.metrics);
 
   const cachedPriceMap = useMemo(() => {
@@ -751,6 +847,12 @@ const SummaryView: React.FC = () => {
     });
   };
 
+  const handleViewPositionsByCurrency = (currency: string) => {
+    navigate("/positions", {
+      state: { ccy: currency },
+    });
+  };
+
   if (isLoading) {
     return (
       <Group justify="center" py="xl">
@@ -827,17 +929,68 @@ const SummaryView: React.FC = () => {
           ) : null}
         </SimpleGrid>
       </Paper>
+      <Paper
+        withBorder
+        p="sm"
+        radius="sm"
+        mb="md"
+        style={{ background: "var(--mantine-color-default-hover)" }}
+      >
+        <Group justify="space-between" align="center" mb="xs">
+          <Text c="dimmed" fw={600} size="sm">
+            Historical P&amp;L
+          </Text>
+          {headlinePnl.asOf ? (
+            <Text c="dimmed" size="xs">
+              Through {new Date(headlinePnl.asOf).toLocaleDateString()}
+            </Text>
+          ) : null}
+        </Group>
+        <SimpleGrid cols={{ base: 2, sm: 5 }} spacing="xs">
+          <PeriodPnlHeadline
+            label="1W"
+            value={headlinePnl.oneWeek}
+            isLoading={isHistoricalMetricsLoading}
+            hasError={hasHistoricalMetricsError}
+          />
+          <PeriodPnlHeadline
+            label="MTD"
+            value={headlinePnl.mtd}
+            isLoading={isHistoricalMetricsLoading}
+            hasError={hasHistoricalMetricsError}
+          />
+          <PeriodPnlHeadline
+            label="3M"
+            value={headlinePnl.threeMonth}
+            isLoading={isHistoricalMetricsLoading}
+            hasError={hasHistoricalMetricsError}
+          />
+          <PeriodPnlHeadline
+            label="6M"
+            value={headlinePnl.sixMonth}
+            isLoading={isHistoricalMetricsLoading}
+            hasError={hasHistoricalMetricsError}
+          />
+          <PeriodPnlHeadline
+            label="YTD"
+            value={headlinePnl.ytd}
+            isLoading={isHistoricalMetricsLoading}
+            hasError={hasHistoricalMetricsError}
+          />
+        </SimpleGrid>
+      </Paper>
       <SimpleGrid cols={{ base: 1, lg: 2 }} spacing="md" style={{ minWidth: 0 }}>
         <SummaryTable
           title="By Book"
           rows={byBook}
           showDailyPnl={hasCachedMetrics}
-          onViewPositionsByBook={handleViewPositionsByBook}
+          onViewPositions={handleViewPositionsByBook}
         />
         <SummaryTable
           title="By Currency"
           rows={byCurrency}
           showDailyPnl={hasCachedMetrics}
+          onViewPositions={handleViewPositionsByCurrency}
         />
         <SummaryTable
           title="By Category"
@@ -853,6 +1006,14 @@ const SummaryView: React.FC = () => {
           showDailyPnl={hasCachedMetrics}
         />
       </SimpleGrid>
+      <MonthlyPortfolioActivityTable
+        rows={monthlyActivity}
+        referenceData={refData}
+        isMetricsLoading={isHistoricalMetricsLoading}
+        areTradesLoading={areTradesLoading}
+        hasMetricsError={hasHistoricalMetricsError}
+        hasTradeError={hasTradesError}
+      />
     </Box>
   );
 };

--- a/web/ui/src/components/Summary/monthlyActivity.test.ts
+++ b/web/ui/src/components/Summary/monthlyActivity.test.ts
@@ -1,0 +1,124 @@
+import { describe, expect, it } from "vitest";
+import type { TimestampedMetrics } from "../Analytics/types";
+import type { Trade } from "../../types/blotter";
+import { buildMonthlyPortfolioActivity } from "./monthlyActivity";
+
+const metric = (
+  timestamp: string,
+  pnl: number,
+  dividends: number,
+  marketValue: number,
+): TimestampedMetrics => ({
+  timestamp,
+  metrics: {
+    irr: 0,
+    mv: marketValue,
+    pricePaid: marketValue + dividends - pnl,
+    totalDividends: dividends,
+  },
+});
+
+const trade = (overrides: Partial<Trade>): Trade => ({
+  TradeID: "trade-1",
+  TradeDate: "2026-06-10T00:00:00Z",
+  Ticker: "AAPL",
+  Book: "Main",
+  Broker: "Broker",
+  Account: "Account",
+  Quantity: 10,
+  Price: 100,
+  Fx: 1.3,
+  TradeType: false,
+  Side: "buy",
+  SeqNum: 1,
+  ...overrides,
+});
+
+describe("buildMonthlyPortfolioActivity", () => {
+  it("builds twelve calendar months of portfolio metrics and ticker-level trades", () => {
+    const rows = buildMonthlyPortfolioActivity(
+      [
+        metric("2026-05-31T00:00:00Z", 10, 1, 900),
+        metric("2026-06-30T00:00:00Z", 30, 5, 1_100),
+        metric("2026-07-01T00:00:00Z", 30, 5, 1_100),
+        metric("2026-07-31T00:00:00Z", 20, 8, 1_050),
+        metric("2026-08-01T00:00:00Z", 25, 8, 1_075),
+        metric("2026-08-15T00:00:00Z", 50, 10, 1_200),
+      ],
+      [
+        trade({}),
+        trade({
+          TradeID: "trade-2",
+          TradeDate: "2026-06-20T00:00:00Z",
+          Quantity: 5,
+          Price: 120,
+          SeqNum: 2,
+        }),
+        trade({ TradeID: "trade-3", Side: "sell", Quantity: 2, SeqNum: 3 }),
+        trade({
+          TradeID: "trade-4",
+          TradeDate: "2026-07-12T00:00:00Z",
+          Ticker: "MSFT",
+          Price: 200,
+          Fx: 1.2,
+          SeqNum: 4,
+        }),
+      ],
+      new Date("2026-08-15T00:00:00Z"),
+    );
+
+    expect(rows.map((row) => row.monthLabel)).toEqual([
+      "Aug-26",
+      "Jul-26",
+      "Jun-26",
+      "May-26",
+      "Apr-26",
+      "Mar-26",
+      "Feb-26",
+      "Jan-26",
+      "Dec-25",
+      "Nov-25",
+      "Oct-25",
+      "Sep-25",
+    ]);
+    expect(rows[2]).toMatchObject({
+      mtdPnl: 20,
+      dividends: 4,
+      netCashFlow: 1_820,
+      marketValue: 1_100,
+    });
+    expect(rows[2].trades).toHaveLength(1);
+    expect(rows[2].trades[0].earliestTradeDate).toBe("2026-06-10");
+    expect(rows[2].trades[0].quantityBought).toBe(15);
+    expect(rows[2].trades[0].quantitySold).toBe(2);
+    expect(rows[2].trades[0].netQuantity).toBe(13);
+    expect(rows[2].trades[0].averagePrice).toBeCloseTo(105.88, 2);
+    expect(rows[2].trades[0].pricePaid).toBe(1_820);
+    expect(rows[1].trades[0]).toMatchObject({
+      ticker: "MSFT",
+      earliestTradeDate: "2026-07-12",
+      quantityBought: 10,
+      quantitySold: 0,
+      netQuantity: 10,
+      averagePrice: 200,
+      pricePaid: 2_400,
+    });
+  });
+
+  it("keeps monthly metrics unavailable when there is no baseline history", () => {
+    const rows = buildMonthlyPortfolioActivity(
+      [metric("2026-08-15T00:00:00Z", 50, 10, 1_200)],
+      [],
+      new Date("2026-08-15T00:00:00Z"),
+    );
+
+    expect(rows[0]).toMatchObject({
+      monthLabel: "Aug-26",
+      mtdPnl: undefined,
+      dividends: undefined,
+      netCashFlow: 0,
+      marketValue: 1_200,
+      trades: [],
+    });
+  });
+});

--- a/web/ui/src/components/Summary/monthlyActivity.ts
+++ b/web/ui/src/components/Summary/monthlyActivity.ts
@@ -1,0 +1,204 @@
+import type { TimestampedMetrics } from "../Analytics/types";
+import type { Trade } from "../../types/blotter";
+
+export interface MonthlyTickerActivity {
+  ticker: string;
+  earliestTradeDate: string;
+  quantityBought: number;
+  quantitySold: number;
+  netQuantity: number;
+  averagePrice: number;
+  pricePaid: number;
+}
+
+export interface MonthlyPortfolioActivity {
+  monthKey: string;
+  monthLabel: string;
+  mtdPnl?: number;
+  dividends?: number;
+  netCashFlow: number;
+  marketValue?: number;
+  trades: MonthlyTickerActivity[];
+}
+
+interface NormalizedSnapshot {
+  timestamp: number;
+  pnl: number;
+  dividends: number;
+  marketValue: number;
+}
+
+const monthNames = [
+  "Jan",
+  "Feb",
+  "Mar",
+  "Apr",
+  "May",
+  "Jun",
+  "Jul",
+  "Aug",
+  "Sep",
+  "Oct",
+  "Nov",
+  "Dec",
+];
+
+const dateOnlyTimestamp = (timestamp: string) => {
+  const [year, month, day] = timestamp.slice(0, 10).split("-").map(Number);
+  if (![year, month, day].every(Number.isInteger)) {
+    return Number.NaN;
+  }
+  return Date.UTC(year, month - 1, day);
+};
+
+const normalizeSnapshots = (
+  historicalMetrics: TimestampedMetrics[],
+): NormalizedSnapshot[] =>
+  historicalMetrics
+    .map((snapshot) => ({
+      timestamp: dateOnlyTimestamp(snapshot.timestamp),
+      pnl:
+        snapshot.metrics.mv -
+        snapshot.metrics.pricePaid +
+        snapshot.metrics.totalDividends,
+      dividends: snapshot.metrics.totalDividends,
+      marketValue: snapshot.metrics.mv,
+    }))
+    .filter((snapshot) =>
+      Object.values(snapshot).every((value) => Number.isFinite(value)),
+    )
+    .sort((left, right) => left.timestamp - right.timestamp);
+
+const aggregateTrades = (
+  trades: Trade[],
+  monthStart: number,
+  nextMonthStart: number,
+) => {
+  const tickerTrades = new Map<
+    string,
+    {
+      quantityBought: number;
+      quantitySold: number;
+      totalQuantity: number;
+      weightedPrice: number;
+      pricePaid: number;
+      earliestTradeTimestamp: number;
+    }
+  >();
+
+  trades.forEach((trade) => {
+    const tradeTimestamp = dateOnlyTimestamp(trade.TradeDate);
+    if (
+      !["buy", "sell"].includes(trade.Side.toLowerCase()) ||
+      tradeTimestamp < monthStart ||
+      tradeTimestamp >= nextMonthStart ||
+      !Number.isFinite(trade.Quantity) ||
+      !Number.isFinite(trade.Price)
+    ) {
+      return;
+    }
+
+    const current = tickerTrades.get(trade.Ticker) || {
+      quantityBought: 0,
+      quantitySold: 0,
+      totalQuantity: 0,
+      weightedPrice: 0,
+      pricePaid: 0,
+      earliestTradeTimestamp: tradeTimestamp,
+    };
+    const fx = Number.isFinite(trade.Fx) && trade.Fx > 0 ? trade.Fx : 1;
+    const isBuy = trade.Side.toLowerCase() === "buy";
+    if (isBuy) {
+      current.quantityBought += trade.Quantity;
+    } else {
+      current.quantitySold += trade.Quantity;
+    }
+    current.totalQuantity += trade.Quantity;
+    current.weightedPrice += trade.Price * trade.Quantity;
+    current.pricePaid +=
+      trade.Price * trade.Quantity * fx * (isBuy ? 1 : -1);
+    current.earliestTradeTimestamp = Math.min(
+      current.earliestTradeTimestamp,
+      tradeTimestamp,
+    );
+    tickerTrades.set(trade.Ticker, current);
+  });
+
+  return Array.from(tickerTrades.entries())
+    .map(([ticker, purchase]) => ({
+      ticker,
+      earliestTradeDate: new Date(purchase.earliestTradeTimestamp)
+        .toISOString()
+        .slice(0, 10),
+      quantityBought: purchase.quantityBought,
+      quantitySold: purchase.quantitySold,
+      netQuantity: purchase.quantityBought - purchase.quantitySold,
+      averagePrice: purchase.totalQuantity
+        ? purchase.weightedPrice / purchase.totalQuantity
+        : 0,
+      pricePaid: purchase.pricePaid,
+    }))
+    .sort(
+      (left, right) =>
+        right.pricePaid - left.pricePaid ||
+        left.ticker.localeCompare(right.ticker),
+    );
+};
+
+export const buildMonthlyPortfolioActivity = (
+  historicalMetrics: TimestampedMetrics[],
+  trades: Trade[],
+  now = new Date(),
+  monthCount = 12,
+): MonthlyPortfolioActivity[] => {
+  const snapshots = normalizeSnapshots(historicalMetrics);
+  const currentYear = now.getFullYear();
+  const currentMonth = now.getMonth();
+
+  return Array.from({ length: monthCount }, (_, index) => {
+    const monthOffset = -index;
+    const monthStartDate = new Date(
+      Date.UTC(currentYear, currentMonth + monthOffset, 1),
+    );
+    const monthStart = monthStartDate.getTime();
+    const nextMonthStart = Date.UTC(
+      monthStartDate.getUTCFullYear(),
+      monthStartDate.getUTCMonth() + 1,
+      1,
+    );
+    const snapshotsInMonth = snapshots.filter(
+      (snapshot) =>
+        snapshot.timestamp >= monthStart &&
+        snapshot.timestamp < nextMonthStart,
+    );
+    const latest = snapshotsInMonth.at(-1);
+    const baseline = latest
+      ? [...snapshots]
+          .reverse()
+          .find(
+            (snapshot) =>
+              snapshot.timestamp <= monthStart &&
+              snapshot.timestamp < latest.timestamp,
+          )
+      : undefined;
+    const year = monthStartDate.getUTCFullYear();
+    const month = monthStartDate.getUTCMonth();
+    const monthlyTrades = aggregateTrades(trades, monthStart, nextMonthStart);
+
+    return {
+      monthKey: `${year}-${String(month + 1).padStart(2, "0")}`,
+      monthLabel: `${monthNames[month]}-${String(year).slice(-2)}`,
+      mtdPnl: latest && baseline ? latest.pnl - baseline.pnl : undefined,
+      dividends:
+        latest && baseline
+          ? latest.dividends - baseline.dividends
+          : undefined,
+      netCashFlow: monthlyTrades.reduce(
+        (sum, trade) => sum + trade.pricePaid,
+        0,
+      ),
+      marketValue: latest?.marketValue,
+      trades: monthlyTrades,
+    };
+  });
+};

--- a/web/ui/src/components/Summary/summaryMetrics.test.ts
+++ b/web/ui/src/components/Summary/summaryMetrics.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from "vitest";
+import type { TimestampedMetrics } from "../Analytics/types";
+import { calculateHeadlinePnlMetrics } from "./summaryMetrics";
+
+const snapshot = (timestamp: string, pnl: number): TimestampedMetrics => ({
+  timestamp,
+  metrics: {
+    irr: 0,
+    mv: 1_000 + pnl,
+    pricePaid: 1_000,
+    totalDividends: 0,
+  },
+});
+
+describe("calculateHeadlinePnlMetrics", () => {
+  it("calculates 1W, MTD, trailing 3M, 6M, and YTD P&L from unsorted snapshots", () => {
+    const result = calculateHeadlinePnlMetrics([
+      snapshot("2026-08-15T00:00:00Z", 180),
+      snapshot("2025-12-31T00:00:00Z", 20),
+      snapshot("2026-02-15T00:00:00Z", 40),
+      snapshot("2026-07-31T00:00:00Z", 130),
+      snapshot("2026-05-15T00:00:00Z", 80),
+      snapshot("2026-08-08T00:00:00Z", 150),
+    ]);
+
+    expect(result.oneWeek).toBe(30);
+    expect(result.mtd).toBe(50);
+    expect(result.threeMonth).toBe(100);
+    expect(result.sixMonth).toBe(140);
+    expect(result.ytd).toBe(160);
+    expect(result.asOf).toBe("2026-08-15T00:00:00.000Z");
+  });
+
+  it("leaves periods unavailable when a new portfolio lacks a baseline", () => {
+    const result = calculateHeadlinePnlMetrics([
+      snapshot("2026-08-10T00:00:00Z", 25),
+      snapshot("2026-08-15T00:00:00Z", 40),
+    ]);
+
+    expect(result.oneWeek).toBeUndefined();
+    expect(result.mtd).toBeUndefined();
+    expect(result.threeMonth).toBeUndefined();
+    expect(result.sixMonth).toBeUndefined();
+    expect(result.ytd).toBeUndefined();
+  });
+
+  it("returns no values when historical metrics are empty", () => {
+    expect(calculateHeadlinePnlMetrics([])).toEqual({});
+  });
+});

--- a/web/ui/src/components/Summary/summaryMetrics.ts
+++ b/web/ui/src/components/Summary/summaryMetrics.ts
@@ -1,0 +1,98 @@
+import type { TimestampedMetrics } from "../Analytics/types";
+
+export interface HeadlinePnlMetrics {
+  asOf?: string;
+  oneWeek?: number;
+  mtd?: number;
+  threeMonth?: number;
+  sixMonth?: number;
+  ytd?: number;
+}
+
+const snapshotPnl = (snapshot: TimestampedMetrics) =>
+  snapshot.metrics.mv -
+  snapshot.metrics.pricePaid +
+  snapshot.metrics.totalDividends;
+
+const subtractCalendarMonths = (date: Date, months: number) => {
+  const targetMonth = date.getUTCMonth() - months;
+  const lastDayOfTargetMonth = new Date(
+    Date.UTC(date.getUTCFullYear(), targetMonth + 1, 0),
+  ).getUTCDate();
+
+  return new Date(
+    Date.UTC(
+      date.getUTCFullYear(),
+      targetMonth,
+      Math.min(date.getUTCDate(), lastDayOfTargetMonth),
+    ),
+  );
+};
+
+const snapshotDate = (timestamp: string) => {
+  const dateParts = timestamp.slice(0, 10).split("-").map(Number);
+  if (
+    dateParts.length !== 3 ||
+    dateParts.some((part) => !Number.isInteger(part))
+  ) {
+    return Number.NaN;
+  }
+
+  const [year, month, day] = dateParts;
+  return Date.UTC(year, month - 1, day);
+};
+
+const pnlSince = (
+  snapshots: Array<{ timestamp: number; pnl: number }>,
+  latest: { timestamp: number; pnl: number },
+  periodStart: Date,
+) => {
+  const startTime = periodStart.getTime();
+  const baseline = [...snapshots]
+    .reverse()
+    .find(
+      (snapshot) =>
+        snapshot.timestamp <= startTime &&
+        snapshot.timestamp < latest.timestamp,
+    );
+
+  return baseline ? latest.pnl - baseline.pnl : undefined;
+};
+
+export const calculateHeadlinePnlMetrics = (
+  historicalMetrics: TimestampedMetrics[],
+): HeadlinePnlMetrics => {
+  const snapshots = historicalMetrics
+    .map((snapshot) => ({
+      timestamp: snapshotDate(snapshot.timestamp),
+      pnl: snapshotPnl(snapshot),
+    }))
+    .filter(
+      (snapshot) =>
+        Number.isFinite(snapshot.timestamp) && Number.isFinite(snapshot.pnl),
+    )
+    .sort((left, right) => left.timestamp - right.timestamp);
+
+  const latest = snapshots.at(-1);
+  if (!latest) {
+    return {};
+  }
+
+  const latestDate = new Date(latest.timestamp);
+  const monthStart = new Date(
+    Date.UTC(latestDate.getUTCFullYear(), latestDate.getUTCMonth(), 1),
+  );
+  const yearStart = new Date(Date.UTC(latestDate.getUTCFullYear(), 0, 1));
+  const oneWeekStart = new Date(latest.timestamp - 7 * 24 * 60 * 60 * 1_000);
+  const threeMonthStart = subtractCalendarMonths(latestDate, 3);
+  const sixMonthStart = subtractCalendarMonths(latestDate, 6);
+
+  return {
+    asOf: latestDate.toISOString(),
+    oneWeek: pnlSince(snapshots, latest, oneWeekStart),
+    mtd: pnlSince(snapshots, latest, monthStart),
+    threeMonth: pnlSince(snapshots, latest, threeMonthStart),
+    sixMonth: pnlSince(snapshots, latest, sixMonthStart),
+    ytd: pnlSince(snapshots, latest, yearStart),
+  };
+};


### PR DESCRIPTION
## Summary

This PR makes the portfolio summary more useful for day-to-day review, adds editing support for historical metrics, and improves recovery from expired Google Drive credentials.

## What changed

### Portfolio summary

- Added a compact Historical P&L section showing 1W, MTD, trailing 3M, trailing 6M, and YTD P&L, calculated from historical metric snapshots.
- Added loading, error, and insufficient-history states so new portfolios do not display misleading values.
- Added a newest-first Past 12 Months table with monthly MTD P&L, dividends, net cash flow, and portfolio market value.
- Made each month expandable to show blotter activity aggregated by ticker rather than individual trades.
- The expanded view combines buys and sells and shows the earliest trade date, bought/sold/net quantity, weighted average transaction price, and net price paid. Trade FX is included, sell proceeds offset purchases, and negative cash flows are highlighted in red.
- Added drill-through from the By Currency summary table to the Positions page with the relevant currency filter applied, matching the existing By Book behavior.

### Historical metrics

- Added an Update Record action to Analytics / Metrics for a single selected record.
- Added an edit modal for market value, price paid, total dividends, and IRR while keeping the record timestamp fixed.
- Added numeric validation, a calculated P&L preview, success/error notifications, and automatic data refresh after saving through the historical metrics API.

### Google Drive backup authentication

- Detects OAuth `invalid_grant` refresh failures and archives the expired token before starting re-authentication.
- Preserves any previous `.expired` token archive by timestamping it before replacement.
- Added tests for invalid-grant detection and token archival behavior.

## Test coverage

- Added unit tests for historical headline P&L calculations, including insufficient-history scenarios.
- Added unit tests for the 12-month portfolio activity and ticker-level buy/sell aggregation.
- Added Go tests for Google Drive expired-token handling.
